### PR TITLE
 [FIP-1.b] Contracts Part 2: Remove old data from index table (FIO #185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ## Version : 2.3.0
 
+
 Smart contracts that provide some of the basic functions of the FIO blockchain
 
 This repository contains examples of these privileged contracts that are useful when deploying, managing, and/or using an FIO blockchain.  They are provided for reference purposes:

--- a/contracts/fio.address/fio.address.cpp
+++ b/contracts/fio.address/fio.address.cpp
@@ -11,7 +11,6 @@
 #include <fio.common/fiotime.hpp>
 #include <fio.token/include/fio.token/fio.token.hpp>
 #include <eosiolib/asset.hpp>
-#include <fio.request.obt/fio.request.obt.hpp> //TEMP FOR XFERADDRESS
 
 namespace fioio {
 
@@ -30,8 +29,6 @@ namespace fioio {
         eosiosystem::producers_table producers;
         eosiosystem::locked_tokens_table lockedTokensTable;
         config appConfig;
-        recordobt_table recordObtTable; //TEMP FOR XFERADDRESS
-        fiorequest_contexts_table fiorequestContextsTable; //TEMP FOR XFERADDRESS
 
     public:
         using contract::contract;
@@ -46,9 +43,7 @@ namespace fioio {
                                                                         voters(SYSTEMACCOUNT, SYSTEMACCOUNT.value),
                                                                         topprods(SYSTEMACCOUNT, SYSTEMACCOUNT.value),
                                                                         producers(SYSTEMACCOUNT, SYSTEMACCOUNT.value),
-                                                                        lockedTokensTable(SYSTEMACCOUNT,SYSTEMACCOUNT.value),
-                                                                        recordObtTable(REQOBTACCOUNT, REQOBTACCOUNT.value), //TEMP FOR XFERADDRESS
-                                                                        fiorequestContextsTable(REQOBTACCOUNT, REQOBTACCOUNT.value){ //TEMP FOR XFERADDRESS
+                                                                        lockedTokensTable(SYSTEMACCOUNT,SYSTEMACCOUNT.value){
             configs_singleton configsSingleton(FeeContract, FeeContract.value);
             appConfig = configsSingleton.get_or_default(config());
         }
@@ -1390,24 +1385,6 @@ namespace fioio {
 
             fio_403_assert(fioname_iter->owner_account == actor.value, ErrorSignature);
             const uint128_t endpoint_hash = string_to_uint128_hash(TRANSFER_ADDRESS_ENDPOINT);
-
-            //TEMP
-            auto obtbyname = recordObtTable.get_index<"bypayee"_n>();
-            auto name_iter = obtbyname.find(nameHash);
-            check(name_iter == obtbyname.end(), "Transfering a FIO address is currently disabled for some fio.addresses");
-
-            auto obtbyname2 = recordObtTable.get_index<"bypayer"_n>();
-            auto name_iter2 = obtbyname2.find(nameHash);
-            check(name_iter2 == obtbyname2.end(), "Transfering a FIO address is currently disabled for some fio.addresses");
-
-            auto reqbyname = fiorequestContextsTable.get_index<"byreceiver"_n>();
-            auto name_iter3 = reqbyname.find(nameHash);
-            check(name_iter3 == reqbyname.end(), "Transfering a FIO address is currently disabled for some fio.addresses");
-
-            auto reqbyname2 = fiorequestContextsTable.get_index<"byoriginator"_n>();
-            auto name_iter4 = reqbyname2.find(nameHash);
-            check(name_iter4 == reqbyname2.end(), "Transfering a FIO address is currently disabled for some fio.addresses");
-            //TEMP
 
             auto fees_by_endpoint = fiofees.get_index<"byendpoint"_n>();
             auto fee_iter = fees_by_endpoint.find(endpoint_hash);

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -535,12 +535,10 @@ namespace fioio {
                         strc.beginrq = id;
                     });
                 }
-            }
 
             const string response_string =
                     string("{\"fio_request_id\":") + to_string(id) + string(",\"status\":\"requested\"") +
                     string(",\"fee_collected\":") + to_string(fee_amount) + string("}");
-
 
             if (NEWFUNDSREQUESTRAM > 0) {
                 action(
@@ -816,7 +814,7 @@ namespace fioio {
                                "Fee exceeds supplied maximum.",
                                ErrorMaxFeeExceeded);
 
-                fio_fees(aactor, asset(fee_amount, FIOSYMBOL));
+                fio_fees(aactor, asset(fee_amount, FIOSYMBOL), CANCEL_FUNDS_REQUEST_ENDPOINT);
                 process_rewards(tpid, fee_amount, get_self(), aactor);
 
                 if (fee_amount > 0) {

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -82,6 +82,7 @@ namespace fioio {
             while (obtTable != recordObtTable.end()) { //obt record migrate
                 recordObtTable.erase(obtTable);
                 count++;
+                obtTable = recordObtTable.begin();
                 if (count == limit) { return; }
             }
 
@@ -89,6 +90,7 @@ namespace fioio {
                 while (reqTable != fiorequestContextsTable.end()) {
                     fiorequestContextsTable.erase(reqTable);
                     count++;
+                    reqTable = fiorequestContextsTable.begin();
                     if (count == limit) { return; }
                 }
             }
@@ -97,6 +99,7 @@ namespace fioio {
                 while (statTable != fiorequestStatusTable.end()) {
                     fiorequestStatusTable.erase(statTable);
                     count++;
+                    statTable = fiorequestStatusTable.begin();
                     if (count == limit) { return; }
                 }
             }

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -79,7 +79,7 @@ namespace fioio {
             auto trxTable = fioTransactionsTable.begin();
 
             auto migrLedger = mgrStatsTable.begin();
-            if (migrLedger != mgrStatsTable.end) { mgrStatsTable.erase(migrLedger); }
+            if (migrLedger != mgrStatsTable.end()) { mgrStatsTable.erase(migrLedger); }
 
             while (obtTable != recordObtTable.end()) { //obt record migrate
                 recordObtTable.erase(obtTable);

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -263,8 +263,13 @@ namespace fioio {
                 const uint64_t id = fioTransactionsTable.available_primary_key();
                 const uint128_t toHash = string_to_uint128_hash(payee_fio_address.c_str());
                 const uint128_t fromHash = string_to_uint128_hash(payer_fio_address.c_str());
-                const uint128_t payeeKeyHash = string_to_uint128_hash(payee_key.c_str());
-                const uint128_t payerKeyHash = string_to_uint128_hash(payer_key.c_str());
+
+                string payee_account;
+                string payer_account;
+                key_to_account(payee_key, payee_account);
+                key_to_account(payer_key, payer_account);
+                const uint128_t payeeKeyHash = string_to_uint128_hash(payee_account);
+                const uint128_t payerKeyHash = string_to_uint128_hash(payer_account);
 
                 fioTransactionsTable.emplace(aactor, [&](struct fiotrxt &obtinf) {
                     obtinf.id = id;
@@ -277,8 +282,8 @@ namespace fioio {
                     obtinf.payee_fio_addr = payee_fio_address;
                     obtinf.payee_key = payee_key;
                     obtinf.payer_key = payer_key;
-                    obtinf.payee_key_hex = payeeKeyHash;
-                    obtinf.payer_key_hex = payerKeyHash;
+                    obtinf.payee_account = payeeKeyHash;
+                    obtinf.payer_account = payerKeyHash;
                 });
             }
 
@@ -437,8 +442,12 @@ namespace fioio {
             const uint64_t currentTime = now();
             const uint128_t toHash = string_to_uint128_hash(payee_fio_address.c_str());
             const uint128_t fromHash = string_to_uint128_hash(payer_fio_address.c_str());
-            const uint128_t payeeKeyHash = string_to_uint128_hash(payee_key.c_str());
-            const uint128_t payerKeyHash = string_to_uint128_hash(payer_key.c_str());
+            string payee_account;
+            string payer_account;
+            key_to_account(payee_key, payee_account);
+            key_to_account(payer_key, payer_account);
+            const uint128_t payeeKeyHash = string_to_uint128_hash(payee_account);
+            const uint128_t payerKeyHash = string_to_uint128_hash(payer_account);
 
             fioTransactionsTable.emplace(aActor, [&](struct fiotrxt &frc) {
                 frc.id = id;
@@ -452,8 +461,8 @@ namespace fioio {
                 frc.payee_fio_addr = payee_fio_address;
                 frc.payee_key = payee_key;
                 frc.payer_key = payer_key;
-                frc.payee_key_hex = payeeKeyHash;
-                frc.payer_key_hex = payerKeyHash;
+                frc.payee_account = payeeKeyHash;
+                frc.payer_account = payerKeyHash;
             });
 
             const string response_string =

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -153,7 +153,7 @@ namespace fioio {
             fio_400_assert(fioname_iter != namesbyname.end(), "payer_fio_address", payer_fio_address,
                            "No such FIO Address",
                            ErrorFioNameNotReg);
-            uint64_t account = fioname_iter->owner_account;
+            uint64_t payer_acct = fioname_iter->owner_account;
             uint64_t payernameexp = fioname_iter->expiration;
 
             fio_400_assert(present_time <= payernameexp, "payer_fio_address", payer_fio_address,
@@ -174,7 +174,7 @@ namespace fioio {
             fio_400_assert(present_time <= domexp, "payer_fio_address", payer_fio_address,
                            "FIO Domain expired", ErrorFioNameExpired);
 
-            auto account_iter = clientkeys.find(account);
+            auto account_iter = clientkeys.find(payer_acct);
             fio_400_assert(account_iter != clientkeys.end(), "payer_fio_address", payer_fio_address,
                            "No such FIO Address",
                            ErrorClientKeyNotFound);
@@ -188,10 +188,10 @@ namespace fioio {
                            "No such FIO Address",
                            ErrorFioNameNotReg);
 
-            fio_403_assert(account == aactor.value, ErrorSignature);
+            fio_403_assert(payer_acct == aactor.value, ErrorSignature);
 
-            account = fioname_iter2->owner_account;
-            account_iter = clientkeys.find(account);
+            uint64_t payee_acct = fioname_iter2->owner_account;
+            account_iter = clientkeys.find(payee_acct);
             fio_400_assert(account_iter != clientkeys.end(), "payee_fio_address", payee_fio_address,
                            "No such FIO Address",
                            ErrorClientKeyNotFound);
@@ -264,13 +264,6 @@ namespace fioio {
                 const uint128_t toHash = string_to_uint128_hash(payee_fio_address.c_str());
                 const uint128_t fromHash = string_to_uint128_hash(payer_fio_address.c_str());
 
-                string payee_account;
-                string payer_account;
-                key_to_account(payee_key, payee_account);
-                key_to_account(payer_key, payer_account);
-                const uint128_t payeeKeyHash = string_to_uint128_hash(payee_account);
-                const uint128_t payerKeyHash = string_to_uint128_hash(payer_account);
-
                 fioTransactionsTable.emplace(aactor, [&](struct fiotrxt &obtinf) {
                     obtinf.id = id;
                     obtinf.payer_fio_addr_hex = fromHash;
@@ -282,8 +275,8 @@ namespace fioio {
                     obtinf.payee_fio_addr = payee_fio_address;
                     obtinf.payee_key = payee_key;
                     obtinf.payer_key = payer_key;
-                    obtinf.payee_account = payeeKeyHash;
-                    obtinf.payer_account = payerKeyHash;
+                    obtinf.payee_account = payee_acct;
+                    obtinf.payer_account = payer_acct;
                 });
             }
 
@@ -356,8 +349,8 @@ namespace fioio {
                            "No such FIO Address",
                            ErrorFioNameNotReg);
 
-            uint64_t account = fioname_iter2->owner_account;
-            auto account_iter = clientkeys.find(account);
+            uint64_t payer_acct = fioname_iter2->owner_account;
+            auto account_iter = clientkeys.find(payer_acct);
             fio_400_assert(account_iter != clientkeys.end(), "payer_fio_address", payer_fio_address,
                            "No such FIO Address",
                            ErrorClientKeyNotFound);
@@ -370,8 +363,8 @@ namespace fioio {
                            "No such FIO Address",
                            ErrorFioNameNotReg);
 
-            account = fioname_iter->owner_account;
-            account_iter = clientkeys.find(account);
+            uint64_t payee_acct = fioname_iter->owner_account;
+            account_iter = clientkeys.find(payee_acct);
             fio_400_assert(account_iter != clientkeys.end(), "payee_fio_address", payee_fio_address,
                            "No such FIO Address",
                            ErrorClientKeyNotFound);
@@ -395,7 +388,7 @@ namespace fioio {
             fio_400_assert(present_time <= domexp, "payee_fio_address", payee_fio_address,
                            "FIO Domain expired", ErrorFioNameExpired);
 
-            fio_403_assert(account == aActor.value, ErrorSignature);
+            fio_403_assert(payee_acct == aActor.value, ErrorSignature);
 
             //begin fees, bundle eligible fee logic
             const uint128_t endpoint_hash = string_to_uint128_hash(NEW_FUNDS_REQUEST_ENDPOINT);
@@ -442,12 +435,6 @@ namespace fioio {
             const uint64_t currentTime = now();
             const uint128_t toHash = string_to_uint128_hash(payee_fio_address.c_str());
             const uint128_t fromHash = string_to_uint128_hash(payer_fio_address.c_str());
-            string payee_account;
-            string payer_account;
-            key_to_account(payee_key, payee_account);
-            key_to_account(payer_key, payer_account);
-            const uint128_t payeeKeyHash = string_to_uint128_hash(payee_account);
-            const uint128_t payerKeyHash = string_to_uint128_hash(payer_account);
 
             fioTransactionsTable.emplace(aActor, [&](struct fiotrxt &frc) {
                 frc.id = id;
@@ -461,8 +448,8 @@ namespace fioio {
                 frc.payee_fio_addr = payee_fio_address;
                 frc.payee_key = payee_key;
                 frc.payer_key = payer_key;
-                frc.payee_account = payeeKeyHash;
-                frc.payer_account = payerKeyHash;
+                frc.payee_account = payee_acct;
+                frc.payer_account = payer_acct;
             });
 
             const string response_string =

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -596,8 +596,8 @@ namespace fioio {
             fio_400_assert(fioreqctx_iter != trxtByRequestId.end(), "fio_request_id", fio_request_id,
                            "No such FIO Request", ErrorRequestContextNotFound);
 
-
-            // Add check for requested only. TODO
+            fio_400_assert(fioreqctx_iter->fio_data_type == 0, "fio_request_id", fio_request_id,
+                           "Only pending requests can be rejected.", ErrorRequestStatusInvalid);
 
             const uint128_t payer128FioAddHashed = fioreqctx_iter->payer_fio_addr_hex;
             const string payer_key = fioreqctx_iter->payer_key;
@@ -675,16 +675,6 @@ namespace fioio {
                 }
             }
             //end fees, bundle eligible fee logic
-            
-            string payer_acct;
-            key_to_account(payer_key, payer_acct);
-            auto ledg_iter = ledgerTable.find(name(payer_acct.c_str()).value);
-            auto trxt_vec = ledg_iter->transactions.payer_action_ids;
-            trxt_vec.erase(std::remove(trxt_vec.begin(), trxt_vec.end(), requestId), trxt_vec.end());
-
-            ledgerTable.modify(ledg_iter, _self, [&](struct reqledger &req) {
-                req.transactions.payer_action_ids = trxt_vec;
-            });
 
             trxtByRequestId.modify(fioreqctx_iter, _self, [&](struct fiotrxt &fr) {
                 fr.fio_data_type = static_cast<int64_t >(trxstatus::rejected);

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -265,12 +265,12 @@ namespace fioio {
                 string payee_acct;
                 key_to_account(payee_key, payee_acct);
                 auto ledg_iter = ledgerTable.find(name(payer_account.c_str()).value);
-                auto trxt_vec = ledg_iter->transactions.pending_action_ids;
+                auto trxt_vec = ledg_iter->transactions.payer_action_ids;
                 auto ledg_iter2 = ledgerTable.find(name(payee_acct.c_str()).value);
 
                 trxt_vec.erase(std::remove(trxt_vec.begin(), trxt_vec.end(), requestId), trxt_vec.end());
                 ledgerTable.modify(ledg_iter, _self, [&](struct reqledger &req) {
-                    req.transactions.pending_action_ids = trxt_vec;
+                    req.transactions.payer_action_ids = trxt_vec;
                     req.transactions.obt_action_ids.insert(req.transactions.obt_action_ids.begin(), requestId);
                 });
 
@@ -497,22 +497,22 @@ namespace fioio {
             if (ledg_iter == ledgerTable.end()) {
                 ledgerTable.emplace(aActor, [&](struct reqledger &req) {
                     req.account = name(payer_acct.c_str()).value;
-                    req.transactions.pending_action_ids.insert(req.transactions.pending_action_ids.begin(), id);
+                    req.transactions.payer_action_ids.insert(req.transactions.payer_action_ids.begin(), id);
                 });
             } else {
                 ledgerTable.modify(ledg_iter, _self, [&](struct reqledger &req) {
-                    req.transactions.pending_action_ids.insert(req.transactions.pending_action_ids.begin(), id);
+                    req.transactions.payer_action_ids.insert(req.transactions.payer_action_ids.begin(), id);
                 });
             }
 
             if (ledg_iter2 == ledgerTable.end()) {
                 ledgerTable.emplace(aActor, [&](struct reqledger &req) {
                     req.account = name(payee_acct.c_str()).value;
-                    req.transactions.sent_action_ids.insert(req.transactions.sent_action_ids.begin(), id);
+                    req.transactions.payee_action_ids.insert(req.transactions.payee_action_ids.begin(), id);
                 });
             } else {
                 ledgerTable.modify(ledg_iter2, _self, [&](struct reqledger &req) {
-                    req.transactions.sent_action_ids.insert(req.transactions.sent_action_ids.begin(), id);
+                    req.transactions.payee_action_ids.insert(req.transactions.payee_action_ids.begin(), id);
                 });
             }
 
@@ -679,11 +679,11 @@ namespace fioio {
             string payer_acct;
             key_to_account(payer_key, payer_acct);
             auto ledg_iter = ledgerTable.find(name(payer_acct.c_str()).value);
-            auto trxt_vec = ledg_iter->transactions.pending_action_ids;
+            auto trxt_vec = ledg_iter->transactions.payer_action_ids;
             trxt_vec.erase(std::remove(trxt_vec.begin(), trxt_vec.end(), requestId), trxt_vec.end());
 
             ledgerTable.modify(ledg_iter, _self, [&](struct reqledger &req) {
-                req.transactions.pending_action_ids = trxt_vec;
+                req.transactions.payer_action_ids = trxt_vec;
             });
 
             trxtByRequestId.modify(fioreqctx_iter, _self, [&](struct fiotrxt &fr) {

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -818,19 +818,9 @@ namespace fioio {
                 }
             }
             //end fees, bundle eligible fee logic
-            string payer_acct;
             string payee_acct;
-            key_to_account(payer_key, payer_acct);
             key_to_account(payee_key, payee_acct);
-            auto ledg_iter = ledgerTable.find(name(payer_acct.c_str()).value);
             auto ledg_iter2 = ledgerTable.find(name(payee_acct.c_str()).value);
-            auto trxt_vec = ledg_iter->transactions.payer_action_ids;
-
-            trxt_vec.erase(std::remove(trxt_vec.begin(), trxt_vec.end(), id), trxt_vec.end());
-
-            ledgerTable.modify(ledg_iter, _self, [&](struct reqledger &req) {
-                req.transactions.payer_action_ids = trxt_vec;
-            });
 
             ledgerTable.modify(ledg_iter2, _self, [&](struct reqledger &req2) {
                 req2.transactions.cancelled_action_ids.insert(req2.transactions.cancelled_action_ids.begin(), id);

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -133,7 +133,7 @@ namespace fioio {
 
     // The request context table holds the requests for funds that have been requested, it provides
     // searching by id, payer and payee.
-    // @abi table fioreqctxts i64
+    // @abi table fiotrxts i64
     struct [[eosio::action]] fiotrxt {
         uint64_t id;
         uint64_t fio_request_id = 0;

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -160,8 +160,8 @@ namespace fioio {
         uint64_t by_time() const { return init_time > update_time ? init_time : update_time; }
 
         //Searches by status using bit shifting
-        uint64_t by_payerstat() const { return payer_account + fio_data_type; }
-        uint64_t by_payeestat() const { return payee_account + fio_data_type; }
+        uint64_t by_payerstat() const { return payer_account + static_cast<uint64_t>(fio_data_type); }
+        uint64_t by_payeestat() const { return payee_account + static_cast<uint64_t>(fio_data_type); }
         uint64_t by_payerobt() const {
             return payer_account + (fio_data_type == 2 || fio_data_type == 4);
         }

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -17,11 +17,10 @@
 
 using std::string;
 
-const uint64_t STATUS_MULTIPLIER = 0x1;
-
 namespace fioio {
 
     using namespace eosio;
+    const uint128_t STATUS_MULTIPLIER = 0x1;
 
     // The status of a transaction progresses from requested, to either rejected or sent to blockchain (if funds
     // are sent in response to the request.
@@ -162,23 +161,23 @@ namespace fioio {
         uint64_t by_time() const { return init_time > update_time ? init_time : update_time; }
 
         //Searches by status using bit shifting
-        uint128_t by_payerstat() const { return payer_key_hex + fio_data_type * STATUS_MULTIPLIER; }
-        uint128_t by_payeestat() const { return payee_key_hex + fio_data_type * STATUS_MULTIPLIER; }
+        uint128_t by_payerstat() const { return payer_key_hex + static_cast<uint128_t>(fio_data_type) * STATUS_MULTIPLIER; }
+        uint128_t by_payeestat() const { return payee_key_hex + static_cast<uint128_t>(fio_data_type) * STATUS_MULTIPLIER; }
         uint128_t by_payerobt() const {
             bool obtdata = fio_data_type == 2 || fio_data_type == 4 ? true : false;
-            return payer_key_hex + obtdata * STATUS_MULTIPLIER;
+            return payer_key_hex + static_cast<uint128_t>(obtdata) * STATUS_MULTIPLIER;
         }
         uint128_t by_payeeobt() const {
             bool obtdata = fio_data_type == 2 || fio_data_type == 4 ? true : false;
-            return payee_key_hex + obtdata * STATUS_MULTIPLIER;
+            return payee_key_hex + static_cast<uint128_t>(obtdata) * STATUS_MULTIPLIER;
         }
         uint128_t by_payerreq() const {
             bool reqdata = fio_data_type >= 3 ? true : false;
-            return payee_key_hex + reqdata * STATUS_MULTIPLIER;
+            return payee_key_hex + static_cast<uint128_t>(reqdata) * STATUS_MULTIPLIER;
         }
         uint128_t by_payeereq() const {
             bool reqdata = fio_data_type >= 3 ? true : false;
-            return payee_key_hex + reqdata * STATUS_MULTIPLIER;
+            return payee_key_hex + static_cast<uint128_t>(reqdata) * STATUS_MULTIPLIER;
         }
 
         EOSLIB_SERIALIZE(fiotrxt,

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -17,6 +17,8 @@
 
 using std::string;
 
+const uint64_t STATUS_MULTIPPLIER = 0x1;
+
 namespace fioio {
 
     using namespace eosio;
@@ -161,8 +163,8 @@ namespace fioio {
         uint64_t by_time() const { return init_time > update_time ? init_time : update_time; }
 
         //Searches by status using bit shifting
-        uint128_t by_payerstat() const { return payer_key_hex << fio_data_type; }
-        uint128_t by_payeestat() const { return payee_key_hex << fio_data_type; }
+        uint128_t by_payerstat() const { return payer_key_hex + fio_data_type * STATUS_MULTIPPLIER; }
+        uint128_t by_payeestat() const { return payee_key_hex + fio_data_type * STATUS_MULTIPPLIER; }
 
         EOSLIB_SERIALIZE(fiotrxt,
         (id)(fio_request_id)(payer_fio_addr_hex)(payee_fio_addr_hex)(fio_data_type)(init_time)

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -20,7 +20,6 @@ using std::string;
 namespace fioio {
 
     using namespace eosio;
-    const uint128_t STATUS_MULTIPLIER = 0x1;
 
     // The status of a transaction progresses from requested, to either rejected or sent to blockchain (if funds
     // are sent in response to the request.
@@ -161,23 +160,19 @@ namespace fioio {
         uint64_t by_time() const { return init_time > update_time ? init_time : update_time; }
 
         //Searches by status using bit shifting
-        uint64_t by_payerstat() const { return payer_account + static_cast<uint64_t>(fio_data_type) * STATUS_MULTIPLIER; }
-        uint64_t by_payeestat() const { return payee_account + static_cast<uint64_t>(fio_data_type) * STATUS_MULTIPLIER; }
+        uint64_t by_payerstat() const { return payer_account + (fio_data_type); }
+        uint64_t by_payeestat() const { return payee_account + (fio_data_type); }
         uint64_t by_payerobt() const {
-            bool obtdata = fio_data_type == 2 || fio_data_type == 4 ? true : false;
-            return payer_account + static_cast<uint64_t>(obtdata) * STATUS_MULTIPLIER;
+            return payer_account + (fio_data_type == 2 || fio_data_type == 4);
         }
         uint64_t by_payeeobt() const {
-            bool obtdata = fio_data_type == 2 || fio_data_type == 4 ? true : false;
-            return payee_account + static_cast<uint64_t>(obtdata) * STATUS_MULTIPLIER;
+            return payee_account + (fio_data_type == 2 || fio_data_type == 4);
         }
         uint64_t by_payerreq() const {
-            bool reqdata = fio_data_type >= 3 ? true : false;
-            return payee_account + static_cast<uint64_t>(reqdata) * STATUS_MULTIPLIER;
+            return payee_account + (fio_data_type >= 3);
         }
         uint64_t by_payeereq() const {
-            bool reqdata = fio_data_type >= 3 ? true : false;
-            return payee_account + static_cast<uint64_t>(reqdata) * STATUS_MULTIPLIER;
+            return payee_account + (fio_data_type >= 3);
         }
 
         EOSLIB_SERIALIZE(fiotrxt,

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -55,13 +55,13 @@ namespace fioio {
         uint64_t primary_key() const { return fio_request_id; }
         uint128_t by_receiver() const { return payer_fio_address; }
         uint128_t by_originator() const { return payee_fio_address; }
-        uint128_t by_payerwtime() const { return payer_fio_address_with_time;}
-        uint128_t by_payeewtime() const { return payee_fio_address_with_time;}
+        uint128_t by_payerwtime() const { return payer_fio_address_with_time; }
+        uint128_t by_payeewtime() const { return payee_fio_address_with_time; }
 
         EOSLIB_SERIALIZE(fioreqctxt,
         (fio_request_id)(payer_fio_address)(payee_fio_address)(payer_fio_address_hex_str)(payee_fio_address_hex_str)
                 (payer_fio_address_with_time)(payee_fio_address_with_time)
-        (content)(time_stamp)(payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)
+                (content)(time_stamp)(payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)
         )
     };
 
@@ -96,11 +96,10 @@ namespace fioio {
         uint128_t by_payeewtime() const { return payee_fio_address_with_time; }
         uint128_t by_payerwtime() const { return payer_fio_address_with_time; }
 
-
         EOSLIB_SERIALIZE(recordobt_info,
         (id)(payer_fio_address)(payee_fio_address)(payer_fio_address_hex_str)(payee_fio_address_hex_str)
-        (payer_fio_address_with_time)(payee_fio_address_with_time)
-        (content)(time_stamp)(payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)
+                (payer_fio_address_with_time)(payee_fio_address_with_time)
+                (content)(time_stamp)(payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)
         )
     };
 
@@ -165,6 +164,22 @@ namespace fioio {
         //Searches by status using bit shifting
         uint128_t by_payerstat() const { return payer_key_hex + fio_data_type * STATUS_MULTIPPLIER; }
         uint128_t by_payeestat() const { return payee_key_hex + fio_data_type * STATUS_MULTIPPLIER; }
+        uint128_t by_payerobt() const {
+            bool obtdata = fio_data_type == 2 || fio_data_type == 4 ? true : false;
+            return payer_key_hex + obtdata * STATUS_MULTIPPLIER;
+        }
+        uint128_t by_payeeobt() const {
+            bool obtdata = fio_data_type == 2 || fio_data_type == 4 ? true : false;
+            return payee_key_hex + obtdata * STATUS_MULTIPPLIER;
+        }
+        uint128_t by_payerreq() const {
+            bool reqdata = fio_data_type >= 3 ? true : false;
+            return payee_key_hex + reqdata * STATUS_MULTIPPLIER;
+        }
+        uint128_t by_payeereq() const {
+            bool reqdata = fio_data_type >= 3 ? true : false;
+            return payee_key_hex + reqdata * STATUS_MULTIPPLIER;
+        }
 
         EOSLIB_SERIALIZE(fiotrxt,
         (id)(fio_request_id)(payer_fio_addr_hex)(payee_fio_addr_hex)(fio_data_type)(init_time)
@@ -181,7 +196,11 @@ namespace fioio {
     indexed_by<"bypayeekey"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payeekey>>,
     indexed_by<"bytime"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_time>>,
     indexed_by<"bypayerstat"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payerstat>>,
-    indexed_by<"bypayeestat"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payeestat>
+    indexed_by<"bypayeestat"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payeestat>>,
+    indexed_by<"bypayerobt"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payerobt>>,
+    indexed_by<"bypayeeobt"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payeeobt>>,
+    indexed_by<"bypayerreq"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payerreq>>,
+    indexed_by<"bypayeereq"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payeereq>
     >>
     fiotrxt_contexts_table;
 
@@ -202,7 +221,8 @@ namespace fioio {
 
         uint64_t primary_key() const { return id; }
 
-        EOSLIB_SERIALIZE(migrledger, (id)(beginobt)(currentobt)(beginrq)(currentrq)(beginsta)(currentsta))
+        EOSLIB_SERIALIZE(migrledger, (id)(beginobt)(currentobt)(beginrq)(currentrq)(beginsta)(currentsta)
+        )
     };
 
     typedef multi_index<"migrledgers"_n, migrledger> migrledgers_table;

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -17,7 +17,7 @@
 
 using std::string;
 
-const uint64_t STATUS_MULTIPPLIER = 0x1;
+const uint64_t STATUS_MULTIPLIER = 0x1;
 
 namespace fioio {
 
@@ -162,23 +162,23 @@ namespace fioio {
         uint64_t by_time() const { return init_time > update_time ? init_time : update_time; }
 
         //Searches by status using bit shifting
-        uint128_t by_payerstat() const { return payer_key_hex + fio_data_type * STATUS_MULTIPPLIER; }
-        uint128_t by_payeestat() const { return payee_key_hex + fio_data_type * STATUS_MULTIPPLIER; }
+        uint128_t by_payerstat() const { return payer_key_hex + fio_data_type * STATUS_MULTIPLIER; }
+        uint128_t by_payeestat() const { return payee_key_hex + fio_data_type * STATUS_MULTIPLIER; }
         uint128_t by_payerobt() const {
             bool obtdata = fio_data_type == 2 || fio_data_type == 4 ? true : false;
-            return payer_key_hex + obtdata * STATUS_MULTIPPLIER;
+            return payer_key_hex + obtdata * STATUS_MULTIPLIER;
         }
         uint128_t by_payeeobt() const {
             bool obtdata = fio_data_type == 2 || fio_data_type == 4 ? true : false;
-            return payee_key_hex + obtdata * STATUS_MULTIPPLIER;
+            return payee_key_hex + obtdata * STATUS_MULTIPLIER;
         }
         uint128_t by_payerreq() const {
             bool reqdata = fio_data_type >= 3 ? true : false;
-            return payee_key_hex + reqdata * STATUS_MULTIPPLIER;
+            return payee_key_hex + reqdata * STATUS_MULTIPLIER;
         }
         uint128_t by_payeereq() const {
             bool reqdata = fio_data_type >= 3 ? true : false;
-            return payee_key_hex + reqdata * STATUS_MULTIPPLIER;
+            return payee_key_hex + reqdata * STATUS_MULTIPLIER;
         }
 
         EOSLIB_SERIALIZE(fiotrxt,

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -24,12 +24,12 @@ namespace fioio {
     // The status of a transaction progresses from requested, to either rejected or sent to blockchain (if funds
     // are sent in response to the request.
     enum class trxstatus {
-        requested = 1,
-        rejected = 2,
-        sent_to_blockchain = 3,
-        cancelled = 4,
-        obt_action = 5,
-        other = 6 //Future Use
+        requested = 0,
+        rejected = 1,
+        sent_to_blockchain = 2,
+        cancelled = 3,
+        obt_action = 4,
+        other = 5 //Future Use
     };
 
     // The request context table holds the requests for funds that have been requested, it provides

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -160,8 +160,8 @@ namespace fioio {
         uint64_t by_time() const { return init_time > update_time ? init_time : update_time; }
 
         //Searches by status using bit shifting
-        uint64_t by_payerstat() const { return payer_account + (fio_data_type); }
-        uint64_t by_payeestat() const { return payee_account + (fio_data_type); }
+        uint64_t by_payerstat() const { return payer_account + fio_data_type; }
+        uint64_t by_payeestat() const { return payee_account + fio_data_type; }
         uint64_t by_payerobt() const {
             return payer_account + (fio_data_type == 2 || fio_data_type == 4);
         }
@@ -169,10 +169,10 @@ namespace fioio {
             return payee_account + (fio_data_type == 2 || fio_data_type == 4);
         }
         uint64_t by_payerreq() const {
-            return payee_account + (fio_data_type >= 3);
+            return payee_account + (fio_data_type <= 3);
         }
         uint64_t by_payeereq() const {
-            return payee_account + (fio_data_type >= 3);
+            return payee_account + (fio_data_type <= 3);
         }
 
         EOSLIB_SERIALIZE(fiotrxt,

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -169,7 +169,7 @@ namespace fioio {
             return payee_account + (fio_data_type == 2 || fio_data_type == 4);
         }
         uint64_t by_payerreq() const {
-            return payee_account + (fio_data_type <= 3);
+            return payer_account + (fio_data_type <= 3);
         }
         uint64_t by_payeereq() const {
             return payee_account + (fio_data_type <= 3);

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -146,8 +146,8 @@ namespace fioio {
         string payee_fio_addr;
         string payer_key = nullptr;
         string payee_key = nullptr;
-        uint128_t payer_key_hex;
-        uint128_t payee_key_hex;
+        uint64_t payer_account;
+        uint64_t payee_account;
 
         string content = "";
         uint64_t update_time = 0;
@@ -156,33 +156,33 @@ namespace fioio {
         uint64_t by_requestid() const { return fio_request_id; }
         uint128_t by_receiver() const { return payer_fio_addr_hex; }
         uint128_t by_originator() const { return payee_fio_addr_hex; }
-        uint128_t by_payerkey() const { return payer_key_hex; }
-        uint128_t by_payeekey() const { return payee_key_hex; }
+        uint64_t by_payeracct() const { return payer_account; }
+        uint64_t by_payeeacct() const { return payee_account; }
         uint64_t by_time() const { return init_time > update_time ? init_time : update_time; }
 
         //Searches by status using bit shifting
-        uint128_t by_payerstat() const { return payer_key_hex + static_cast<uint128_t>(fio_data_type) * STATUS_MULTIPLIER; }
-        uint128_t by_payeestat() const { return payee_key_hex + static_cast<uint128_t>(fio_data_type) * STATUS_MULTIPLIER; }
-        uint128_t by_payerobt() const {
+        uint64_t by_payerstat() const { return payer_account + static_cast<uint64_t>(fio_data_type) * STATUS_MULTIPLIER; }
+        uint64_t by_payeestat() const { return payee_account + static_cast<uint64_t>(fio_data_type) * STATUS_MULTIPLIER; }
+        uint64_t by_payerobt() const {
             bool obtdata = fio_data_type == 2 || fio_data_type == 4 ? true : false;
-            return payer_key_hex + static_cast<uint128_t>(obtdata) * STATUS_MULTIPLIER;
+            return payer_account + static_cast<uint64_t>(obtdata) * STATUS_MULTIPLIER;
         }
-        uint128_t by_payeeobt() const {
+        uint64_t by_payeeobt() const {
             bool obtdata = fio_data_type == 2 || fio_data_type == 4 ? true : false;
-            return payee_key_hex + static_cast<uint128_t>(obtdata) * STATUS_MULTIPLIER;
+            return payee_account + static_cast<uint64_t>(obtdata) * STATUS_MULTIPLIER;
         }
-        uint128_t by_payerreq() const {
+        uint64_t by_payerreq() const {
             bool reqdata = fio_data_type >= 3 ? true : false;
-            return payee_key_hex + static_cast<uint128_t>(reqdata) * STATUS_MULTIPLIER;
+            return payee_account + static_cast<uint64_t>(reqdata) * STATUS_MULTIPLIER;
         }
-        uint128_t by_payeereq() const {
+        uint64_t by_payeereq() const {
             bool reqdata = fio_data_type >= 3 ? true : false;
-            return payee_key_hex + static_cast<uint128_t>(reqdata) * STATUS_MULTIPLIER;
+            return payee_account + static_cast<uint64_t>(reqdata) * STATUS_MULTIPLIER;
         }
 
         EOSLIB_SERIALIZE(fiotrxt,
         (id)(fio_request_id)(payer_fio_addr_hex)(payee_fio_addr_hex)(fio_data_type)(init_time)
-                (payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)(payer_key_hex)(payee_key_hex)
+                (payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)(payer_account)(payee_account)
                 (content)(update_time)
         )
     };
@@ -191,15 +191,15 @@ namespace fioio {
             indexed_by<"byrequestid"_n, const_mem_fun < fiotrxt, uint64_t, &fiotrxt::by_requestid>>,
     indexed_by<"byreceiver"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_receiver>>,
     indexed_by<"byoriginator"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_originator>>,
-    indexed_by<"bypayerkey"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payerkey>>,
-    indexed_by<"bypayeekey"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payeekey>>,
+    indexed_by<"bypayeracct"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payeracct>>,
+    indexed_by<"bypayeeacct"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payeeacct>>,
     indexed_by<"bytime"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_time>>,
-    indexed_by<"bypayerstat"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payerstat>>,
-    indexed_by<"bypayeestat"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payeestat>>,
-    indexed_by<"bypayerobt"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payerobt>>,
-    indexed_by<"bypayeeobt"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payeeobt>>,
-    indexed_by<"bypayerreq"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payerreq>>,
-    indexed_by<"bypayeereq"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_payeereq>
+    indexed_by<"bypayerstat"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payerstat>>,
+    indexed_by<"bypayeestat"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payeestat>>,
+    indexed_by<"bypayerobt"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payerobt>>,
+    indexed_by<"bypayeeobt"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payeeobt>>,
+    indexed_by<"bypayerreq"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payerreq>>,
+    indexed_by<"bypayeereq"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payeereq>
     >>
     fiotrxt_contexts_table;
 


### PR DESCRIPTION
This PR gives the functionality of removing old data from the request and obt index tables. Block producers are able to call `migrtrx` and remove up to 25 records during a single transaction. Added functionality also allows for the API endpoints to use the new data structure introduced in step 1.