### PR TITLE
Update develop to 2.1.1 (temp placeholder)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(fio.contracts)
 
 set(VERSION_MAJOR 2)
 set(VERSION_MINOR 1)
-set(VERSION_PATCH 0)
+set(VERSION_PATCH 1)
 #set(VERSION_SUFFIX rc3)
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fio.contracts
 
-## Version : 2.1.0
+## Version : 2.1.1
 
 Smart contracts that provide some of the basic functions of the FIO blockchain
 


### PR DESCRIPTION
Now that changes have been merged after the 2.1.0 release, a new version needs to be cut to signify changes between versions. 