### PR TITLE
change name of action to computefees

### DIFF
--- a/contracts/fio.fee/fio.fee.abi
+++ b/contracts/fio.fee/fio.fee.abi
@@ -67,7 +67,7 @@
             {"name":"bytesize", "type":"int64"}
         ]
       },{
-        "name": "updatefees",
+        "name": "computefees",
         "base": "",
         "fields": [
         ]
@@ -145,8 +145,8 @@
          "type": "bytemandfee",
          "ricardian_contract": ""
        },{
-         "name": "updatefees",
-         "type": "updatefees",
+         "name": "computefees",
+         "type": "computefees",
          "ricardian_contract": ""
        }],
     "tables": [{

--- a/contracts/fio.fee/fio.fee.cpp
+++ b/contracts/fio.fee/fio.fee.cpp
@@ -313,7 +313,7 @@ namespace fioio {
       * This method will update the fees based upon the present votes made by producers.
       */
         [[eosio::action]]
-        void updatefees() {
+        void computefees() {
             uint32_t numberprocessed = update_fees();
             const string response_string = string("{\"status\": \"OK\",\"fees_processed\":") +
                                            to_string(numberprocessed) + string("}");
@@ -659,7 +659,7 @@ namespace fioio {
         }
     };
 
-    EOSIO_DISPATCH(FioFee, (setfeevote)(bundlevote)(setfeemult)(updatefees)
+    EOSIO_DISPATCH(FioFee, (setfeevote)(bundlevote)(setfeemult)(computefees)
                            (mandatoryfee)(bytemandfee)(createfee)
     )
 }


### PR DESCRIPTION
this pr changes the action name in the fee contract from update fees to compute fees, this matches the FIP-10 specification.

