### PR TITLE
FIP-18: Chain-level public address

### DIFF
--- a/contracts/fio.address/fio.address.cpp
+++ b/contracts/fio.address/fio.address.cpp
@@ -301,7 +301,7 @@ namespace fioio {
                 public_address = tpa->public_address.c_str();
 
 
-                fio_400_assert(validateChainNameFormat(token), "token_code", tpa->token_code, "Invalid token code format",
+                fio_400_assert(validateTokenNameFormat(token), "token_code", tpa->token_code, "Invalid token code format",
                                ErrorInvalidFioNameFormat);
                 fio_400_assert(validateChainNameFormat(chaincode), "chain_code", tpa->chain_code, "Invalid chain code format",
                                ErrorInvalidFioNameFormat);
@@ -311,7 +311,7 @@ namespace fioio {
 
                 int idx = 0;
                 for( auto it = fioname_iter->addresses.begin(); it != fioname_iter->addresses.end(); ++it ) {
-                    if( (it->token_code == token) && (it->chain_code == chaincode)  && it->public_address == public_address ){
+                    if( (it->token_code == token) && (it->chain_code == chaincode) && it->public_address == public_address ){
                         wasFound = true;
                         break;
                     }
@@ -432,7 +432,6 @@ namespace fioio {
                 }
             }
 
-
             uint64_t fee_amount = 0;
 
             //begin new fees, bundle eligible fee logic
@@ -478,8 +477,6 @@ namespace fioio {
             return fee_amount;
         }
 
-
-
         uint64_t chain_data_update
          (const string &fioaddress, const vector<tokenpubaddr> &pubaddresses,
                           const uint64_t &max_fee, const FioAddress &fa,
@@ -523,7 +520,7 @@ namespace fioio {
                 token = tpa->token_code.c_str();
                 chaincode = tpa->chain_code.c_str();
 
-                fio_400_assert(validateChainNameFormat(token), "token_code", tpa->token_code, "Invalid token code format",
+                fio_400_assert(validateTokenNameFormat(token), "token_code", tpa->token_code, "Invalid token code format",
                                ErrorInvalidFioNameFormat);
                 fio_400_assert(validateChainNameFormat(chaincode), "chain_code", tpa->chain_code, "Invalid chain code format",
                                ErrorInvalidFioNameFormat);

--- a/contracts/fio.common/fio_common_validator.hpp
+++ b/contracts/fio.common/fio_common_validator.hpp
@@ -95,6 +95,14 @@ namespace fioio {
         return false;
     }
 
+    inline bool validateTokenNameFormat(const string &token) {
+        if(token == "*") {
+            return true;
+        }
+
+        return validateChainNameFormat(token);
+    }
+
     inline bool validateTPIDFormat(const string &tpid) {
         if (tpid.size() > 0) {
             FioAddress fa;


### PR DESCRIPTION
Modifies remaddress and addaddress to allow for the "*" parameter when assigning chain level public addresses. 