### PR TITLE
Update fio.request.obt.abi to remove reqledger

### DIFF
--- a/contracts/fio.request.obt/fio.request.obt.abi
+++ b/contracts/fio.request.obt/fio.request.obt.abi
@@ -443,17 +443,6 @@
          "type":"fiotrxt"
       },
       {
-         "name":"reqledgers",
-         "index_type":"i64",
-         "key_names":[
-            "account"
-         ],
-         "key_types":[
-            "uint64"
-         ],
-         "type":"reqledger"
-      },
-      {
          "name":"migrledgers",
          "index_type":"i64",
          "key_names":[


### PR DESCRIPTION
Seems like one of the references were left. This PR deletes the ref inside the ABI file.