### PR TITLE
Changes needed after Part 2 testing

### DIFF
--- a/contracts/fio.common/fio.common.hpp
+++ b/contracts/fio.common/fio.common.hpp
@@ -408,8 +408,8 @@ namespace fioio {
     static const uint64_t REGADDRESSRAM = 2560; //integrated.
     static const uint64_t ADDADDRESSRAM = 512; //integrated.
     static const uint64_t SETDOMAINPUBRAM = 256; //integrated.
-    static const uint64_t NEWFUNDSREQUESTRAM = 2048; //integrated.
-    static const uint64_t RECORDOBTRAM = 2048; //integrated.
+    static const uint64_t NEWFUNDSREQUESTRAM = 2560; //integrated.
+    static const uint64_t RECORDOBTRAM = 2560; //integrated.
     static const uint64_t RENEWADDRESSRAM = 1024; //integrated.
     static const uint64_t RENEWDOMAINRAM = 1024; //integrated.
     static const uint64_t XFERRAM = 512; //integrated.

--- a/contracts/fio.request.obt/fio.request.obt.abi
+++ b/contracts/fio.request.obt/fio.request.obt.abi
@@ -193,11 +193,11 @@
             },
             {
                "name":"payer_account",
-               "type":"uint64"
+               "type":"name"
             },
             {
                "name":"payee_account",
-               "type":"uint64"
+               "type":"name"
             },
             {
                "name":"content",

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -161,8 +161,8 @@ namespace fioio {
         uint64_t by_time() const { return init_time > update_time ? init_time : update_time; }
 
         //Searches by status using bit shifting
-        uint64_t by_payerstat() const { return payer_account + fio_data_type; }
-        uint64_t by_payeestat() const { return payee_account + fio_data_type; }
+        uint64_t by_payerstat() const { return payer_account + static_cast<uint64_t>(fio_data_type); }
+        uint64_t by_payeestat() const { return payee_account + static_cast<uint64_t>(fio_data_type); }
         uint64_t by_payerobt() const {
             return payer_account + (fio_data_type == 2 || fio_data_type == 4);
         }


### PR DESCRIPTION
- Increase RAM for recordobt and newfundsreq calls from `2048` -> `2560`.

- Add static casting to `fio_data_type`

- Change type from uint64_t to name for payee and payer accounts for better table viewing.