### PR TITLE
Fix bug in second unlocking period.

### DIFF
--- a/contracts/fio.token/include/fio.token/fio.token.hpp
+++ b/contracts/fio.token/include/fio.token/fio.token.hpp
@@ -147,7 +147,7 @@ namespace eosio {
 
                     uint64_t daysSinceGrant =  (int)((present_time  - lockiter->timestamp) / 60);
                     uint64_t firstPayPeriod = 3;
-                    uint64_t payoutTimePeriod = 3;
+                    uint64_t payoutTimePeriod = 15;
 
                     bool ninetyDaysSinceGrant = daysSinceGrant >= firstPayPeriod;
 

--- a/contracts/fio.token/include/fio.token/fio.token.hpp
+++ b/contracts/fio.token/include/fio.token/fio.token.hpp
@@ -141,13 +141,13 @@ namespace eosio {
                 }
                 if (lockiter->unlocked_period_count < 6) {
                     //to shorten the vesting schedule adapt these variables.
-                   // uint32_t daysSinceGrant = (int) ((present_time - lockiter->timestamp) / SECONDSPERDAY);
-                   // uint32_t firstPayPeriod = 90;
-                   // uint32_t payoutTimePeriod = 180;
+                    uint32_t daysSinceGrant = (int) ((present_time - lockiter->timestamp) / SECONDSPERDAY);
+                    uint32_t firstPayPeriod = 90;
+                    uint32_t payoutTimePeriod = 180;
 
-                    uint64_t daysSinceGrant =  (int)((present_time  - lockiter->timestamp) / 60);
-                    uint64_t firstPayPeriod = 3;
-                    uint64_t payoutTimePeriod = 15;
+                    //TEST LOCKED TOKENS uint32_t daysSinceGrant =  (int)((present_time  - lockiter->timestamp) / 60);
+                    //TEST LOCKED TOKENS uint32_t firstPayPeriod = 15;
+                    //TEST LOCKED TOKENS uint32_t payoutTimePeriod = 15;
 
                     bool ninetyDaysSinceGrant = daysSinceGrant >= firstPayPeriod;
 
@@ -161,8 +161,6 @@ namespace eosio {
                     }
 
                     uint64_t numberVestingPayouts = lockiter->unlocked_period_count;
-
-
                     uint64_t remainingPayouts = 0;
                     uint64_t newlockedamount = lockiter->remaining_locked_amount;
                     uint64_t totalgrantamount = lockiter->total_grant_amount;
@@ -235,10 +233,6 @@ namespace eosio {
                         }
                     }
 
-
-
-
-
                     //process the first unlock period.
                     if ((numberVestingPayouts == 0) && (ninetyDaysSinceGrant)) {
                         if ((lockiter->grant_type == 1) ||
@@ -282,12 +276,6 @@ namespace eosio {
                         } else {  //unknown lock type, dont unlock
                             return lockiter->remaining_locked_amount;
                         }
-
-                        //TESTING ONLY, this is the original boinking code
-                        //this is assumed to have 3 decimal places in the specified percentage
-                        //this calc results in 20 digits, when we multiply totalgrantamount by percentperblock
-                        // amountpay = (remainingPayouts * (totalgrantamount * percentperblock)) / 100000;
-                        //TESTING ONLY, this is the orginal boinking code
 
                         //we eliminate the last 5 digits of the SUFs to avoid overflow in the calculations
                         //that follow.


### PR DESCRIPTION
Dev Testing performed:

manual testing was performed on grants with 70M 7M 700k 70k to ensure that unlocking was accurate for the second grant period.

manual testing was performed to demonstrate the correction of the accounting for mis-accounted accounts:
Testing was performed by starting with the 2.2.x contracts with the unlock period shortened. One grant of type 1 was created for 70007834 FIO. The first unlock period was allowed to pass, then voting was performed (the unlock amount was correct), the second unlocking period was allowed to pass and then voting performed again (this time the unlock amount was much smaller than expected), this branches token and system contract were then built and set contract was used to set the token and then the system contract, then voting was performed, it was noted that the amount of the unlocked tokens was corrected. this test was completed on local dev box running 3 nodes test net, and also the FIO private dev net.

Eric Butz -- completed regression testing on the genesis grants that were type 1 and not msig.
Todd Garrison -- completed testing for locked token grants.

both of these individuals reported that testing was clear to proceed in the process of rollout.


thanks for any additional  input or analysis on these changes.

Background

I performed a proxy of my tokens shortly after the second unlock period on main net in order to see if the unlock went as expected. It did not go as expected. the amount unlocked was many times less than expected.  I notified product and the foundation and the dev leadership of the FIO Protocol of the issue, and began to investigate the issue. 

The issue comes about when the code tries to compute an unlock amount for the second unlock period. the code performs a multiplication of the total locked amount (which has 16 digits) by the unlock percentage which is 18800 (and so five digits) the resulting value has 20 digits of value and cannot be stored in a uint64_t which can only store 19 digits maximum. The resulting overflow results in a small amount being computed for the unlock for the period.

a fix was identified which eliminates 5 digits of resolution from the input total lock amount in the calculations.  This seems to work, but needs verified by running on all of the genesis grants within the FIO Protocol. The consequences of the loss of 5 digits of resolution is that the unlock may be .0000X FIO in-accurate. the amount of the in-accuracy will be unlocked in subsequent unlocking periods.

We propose in this PR a fix that addresses both of the 2 issues introduced by this bug.

1) we propose a fix to the computations in the unlock which should not overflow going forward.
2) we propose logic that should verify the remaining lock amount when 2 unlock periods have been paid and which will also correct any mis-accounting that resulted from the first unlock.

it is critical to use exactly the same logic as is used by the unlocking to resolve the mis-accounted accounts, this ensures that there should be no changes to logic for these accounts compared to hose accounts that are unlocked without incident.

