### PR TITLE
fix bug when users try to fix period 2 genesis locks using transfer fio pub key

### DIFF
--- a/contracts/fio.token/include/fio.token/fio.token.hpp
+++ b/contracts/fio.token/include/fio.token/fio.token.hpp
@@ -213,7 +213,7 @@ namespace eosio {
                     if ((numberVestingPayouts == 2)&&
                         ((lockiter->grant_type == 1) ||
                          (lockiter->grant_type == 2) ||
-                         (lockiter->grant_type == 3)))
+                         (lockiter->grant_type == 3)) && doupdate)
                     {
                         //we will compute the total we should have unlocked in this period.
                         //if the amount is greater than what has been unlocked so far we will


### PR DESCRIPTION
fix error when users with mis-accounted period 2 genesis locked tokens try to correct the accounting using tranfer fio pub key.

obey the do update flag properly