### PR TITLE
Request and Obt index table hotfix ( with migration code fixes )

### DIFF
--- a/contracts/fio.request.obt/fio.request.obt.abi
+++ b/contracts/fio.request.obt/fio.request.obt.abi
@@ -148,7 +148,7 @@
          ]
       },
       {
-         "name":"fiotrxt",
+         "name":"fiotrxt_info",
          "base":"",
          "fields":[
             {
@@ -201,6 +201,10 @@
             },
             {
                "name":"content",
+               "type":"string"
+            },
+            {
+               "name":"obt_metadata",
                "type":"string"
             },
             {
@@ -428,7 +432,7 @@
          "type":"fioreqsts"
       },
       {
-         "name":"fiotrxts",
+         "name":"fiotrxtss",
          "index_type":"i64",
          "key_names":[
             "id"
@@ -436,7 +440,7 @@
          "key_types":[
             "uint64"
          ],
-         "type":"fiotrxt"
+         "type":"fiotrxt_info"
       },
       {
          "name":"migrledgers",

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -21,7 +21,7 @@ namespace fioio {
     class [[eosio::contract("FioRequestObt")]]  FioRequestObt : public eosio::contract {
 
     private:
-        fiotrxt_contexts_table fioTransactionsTable; //Migration Table
+        fiotrxts_contexts_table fioTransactionsTable; //Migration Table
         migrledgers_table mgrStatsTable; // Migration Ledger (temp)
         fiorequest_contexts_table fiorequestContextsTable;
         fiorequest_status_table fiorequestStatusTable;
@@ -85,7 +85,7 @@ namespace fioio {
                     key_to_account(reqTable->payee_key, payee_account);
                     name payee_acct = name(payee_account.c_str());
 
-                    fioTransactionsTable.emplace(executor, [&](struct fiotrxt &frc) {
+                    fioTransactionsTable.emplace(executor, [&](struct fiotrxt_info &frc) {
                         frc.id = fioTransactionsTable.available_primary_key();
                         frc.fio_request_id = reqTable->fio_request_id;
                         frc.fio_data_type = static_cast<int64_t>(trxstatus::requested);
@@ -125,7 +125,7 @@ namespace fioio {
                         key_to_account(reqTable->payee_key, payee_account);
                         name payee_acct = name(payee_account.c_str());
 
-                        fioTransactionsTable.emplace(executor, [&](struct fiotrxt &frc) {
+                        fioTransactionsTable.emplace(executor, [&](struct fiotrxt_info &frc) {
                             frc.id = fioTransactionsTable.available_primary_key();
                             frc.fio_request_id = reqid;
                             frc.fio_data_type = static_cast<int64_t>(trxstatus::requested);
@@ -165,7 +165,7 @@ namespace fioio {
                     key_to_account(obtTable->payee_key, payee_account);
                     name payee_acct = name(payee_account.c_str());
 
-                    fioTransactionsTable.emplace(executor, [&](struct fiotrxt &frc) {
+                    fioTransactionsTable.emplace(executor, [&](struct fiotrxt_info &frc) {
                         frc.id = fioTransactionsTable.available_primary_key();;
                         frc.fio_data_type = static_cast<int64_t>(trxstatus::obt_action);
                         frc.payer_fio_addr_hex = obtTable->payer_fio_address;
@@ -201,10 +201,10 @@ namespace fioio {
                     if( statType != fioreqctx_iter->fio_data_type && fioreqctx_iter != trxtByRequestId.end() ){
                         uint64_t id = fioreqctx_iter->id;
 
-                        trxtByRequestId.modify(fioreqctx_iter, _self, [&](struct fiotrxt &fr) {
+                        trxtByRequestId.modify(fioreqctx_iter, _self, [&](struct fiotrxt_info &fr) {
                             fr.fio_data_type = statType;
                             fr.update_time = statTable->time_stamp;
-                            if (statTable->metadata != "") { fr.content = statTable->metadata; }
+                            if (statTable->metadata != "") { fr.obt_metadata = statTable->metadata; }
                         });
 
                         mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {
@@ -385,9 +385,9 @@ namespace fioio {
 
                 // USED FOR MIGRATION
                 if(fioreqctx_iter2 != trxtByRequestId.end()){
-                    trxtByRequestId.modify(fioreqctx_iter2, _self, [&](struct fiotrxt &fr) {
+                    trxtByRequestId.modify(fioreqctx_iter2, _self, [&](struct fiotrxt_info &fr) {
                         fr.fio_data_type = static_cast<int64_t>(trxstatus::sent_to_blockchain);
-                        fr.content = content;
+                        fr.obt_metadata = content;
                         fr.update_time = currentTime;
                     });
                 }
@@ -431,7 +431,7 @@ namespace fioio {
 
                 auto trxt_iter = fioTransactionsTable.begin();
                 if(trxt_iter != fioTransactionsTable.end()){
-                    fioTransactionsTable.emplace(aactor, [&](struct fiotrxt &obtinf) {
+                    fioTransactionsTable.emplace(aactor, [&](struct fiotrxt_info &obtinf) {
                         obtinf.id = fioTransactionsTable.available_primary_key();
                         obtinf.payer_fio_addr_hex = fromHash;
                         obtinf.payee_fio_addr_hex = toHash;
@@ -664,7 +664,7 @@ namespace fioio {
                 name payer_acct = name(payer_account.c_str());
                 name payee_acct = name(payee_account.c_str());
 
-                fioTransactionsTable.emplace(aActor, [&](struct fiotrxt &frc) {
+                fioTransactionsTable.emplace(aActor, [&](struct fiotrxt_info &frc) {
                     frc.id = fioTransactionsTable.available_primary_key();
                     frc.fio_request_id = id;
                     frc.payer_fio_addr_hex = fromHash;
@@ -848,7 +848,7 @@ namespace fioio {
 
             // USED FOR MIGRATION
             if(fioreqctx2_iter != trxtByRequestId.end()){
-                trxtByRequestId.modify(fioreqctx2_iter, _self, [&](struct fiotrxt &fr) {
+                trxtByRequestId.modify(fioreqctx2_iter, _self, [&](struct fiotrxt_info &fr) {
                     fr.fio_data_type = static_cast<int64_t >(trxstatus::rejected);
                     fr.update_time = currentTime;
                 });
@@ -1013,7 +1013,7 @@ namespace fioio {
 
         // USED FOR MIGRATION
         if(fioreqctx2_iter != trxtByRequestId.end()){
-            trxtByRequestId.modify(fioreqctx2_iter, _self, [&](struct fiotrxt &fr) {
+            trxtByRequestId.modify(fioreqctx2_iter, _self, [&](struct fiotrxt_info &fr) {
                 fr.fio_data_type = static_cast<int64_t >(trxstatus::cancelled);
                 fr.update_time = currentTime;
             });

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -435,7 +435,7 @@ namespace fioio {
                         obtinf.id = fioTransactionsTable.available_primary_key();
                         obtinf.payer_fio_addr_hex = fromHash;
                         obtinf.payee_fio_addr_hex = toHash;
-                        obtinf.metadata = content;
+                        obtinf.obt_metadata = content;
                         obtinf.fio_data_type = static_cast<int64_t>(trxstatus::obt_action);
                         obtinf.init_time = currentTime;
                         obtinf.payer_fio_addr = payer_fio_address;

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -435,7 +435,7 @@ namespace fioio {
                         obtinf.id = fioTransactionsTable.available_primary_key();
                         obtinf.payer_fio_addr_hex = fromHash;
                         obtinf.payee_fio_addr_hex = toHash;
-                        obtinf.content = content;
+                        obtinf.metadata = content;
                         obtinf.fio_data_type = static_cast<int64_t>(trxstatus::obt_action);
                         obtinf.init_time = currentTime;
                         obtinf.payer_fio_addr = payer_fio_address;

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -134,8 +134,8 @@ namespace fioio {
 
     // The request context table holds the requests for funds that have been requested, it provides
     // searching by id, payer and payee.
-    // @abi table fiotrxt i64
-    struct [[eosio::action]] fiotrxt {
+    // @abi table fiotrxt_info i64
+    struct [[eosio::action]] fiotrxt_info {
         uint64_t id;
         uint64_t fio_request_id = 0;
         uint128_t payer_fio_addr_hex;
@@ -150,6 +150,7 @@ namespace fioio {
         uint64_t payee_account;
 
         string content = "";
+        string obt_metadata  = "";
         uint64_t update_time = 0;
 
         uint64_t primary_key() const { return id; }
@@ -176,28 +177,28 @@ namespace fioio {
             return payee_account + (fio_data_type <= 3);
         }
 
-        EOSLIB_SERIALIZE(fiotrxt,
+        EOSLIB_SERIALIZE(fiotrxt_info,
         (id)(fio_request_id)(payer_fio_addr_hex)(payee_fio_addr_hex)(fio_data_type)(init_time)
                 (payer_fio_addr)(payee_fio_addr)(payer_key)(payee_key)(payer_account)(payee_account)
-                (content)(update_time)
+                (content)(obt_metadata)(update_time)
         )
     };
 
-    typedef multi_index<"fiotrxts"_n, fiotrxt,
-            indexed_by<"byrequestid"_n, const_mem_fun < fiotrxt, uint64_t, &fiotrxt::by_requestid>>,
-    indexed_by<"byreceiver"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_receiver>>,
-    indexed_by<"byoriginator"_n, const_mem_fun<fiotrxt, uint128_t, &fiotrxt::by_originator>>,
-    indexed_by<"bypayeracct"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payeracct>>,
-    indexed_by<"bypayeeacct"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payeeacct>>,
-    indexed_by<"bytime"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_time>>,
-    indexed_by<"bypayerstat"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payerstat>>,
-    indexed_by<"bypayeestat"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payeestat>>,
-    indexed_by<"bypayerobt"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payerobt>>,
-    indexed_by<"bypayeeobt"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payeeobt>>,
-    indexed_by<"bypayerreq"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payerreq>>,
-    indexed_by<"bypayeereq"_n, const_mem_fun<fiotrxt, uint64_t, &fiotrxt::by_payeereq>
+    typedef multi_index<"fiotrxtss"_n, fiotrxt_info,
+            indexed_by<"byrequestid"_n, const_mem_fun < fiotrxt_info, uint64_t, &fiotrxt_info::by_requestid>>,
+    indexed_by<"byreceiver"_n, const_mem_fun<fiotrxt_info, uint128_t, &fiotrxt_info::by_receiver>>,
+    indexed_by<"byoriginator"_n, const_mem_fun<fiotrxt_info, uint128_t, &fiotrxt_info::by_originator>>,
+    indexed_by<"bypayeracct"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_payeracct>>,
+    indexed_by<"bypayeeacct"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_payeeacct>>,
+    indexed_by<"bytime"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_time>>,
+    indexed_by<"bypayerstat"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_payerstat>>,
+    indexed_by<"bypayeestat"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_payeestat>>,
+    indexed_by<"bypayerobt"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_payerobt>>,
+    indexed_by<"bypayeeobt"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_payeeobt>>,
+    indexed_by<"bypayerreq"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_payerreq>>,
+    indexed_by<"bypayeereq"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_payeereq>
     >>
-    fiotrxt_contexts_table;
+    fiotrxts_contexts_table;
 
     struct [[eosio::action]] migrledger {
 

--- a/contracts/fio.request.obt/fio.request.obt.hpp
+++ b/contracts/fio.request.obt/fio.request.obt.hpp
@@ -159,7 +159,8 @@ namespace fioio {
         uint128_t by_originator() const { return payee_fio_addr_hex; }
         uint64_t by_payeracct() const { return payer_account; }
         uint64_t by_payeeacct() const { return payee_account; }
-        uint64_t by_time() const { return req_time > obt_time ? req_time : obt_time; }
+        uint64_t by_obttime() const { return obt_time; }
+        uint64_t by_reqtime() const { return req_time; }
 
         //Searches by status using bit shifting
         uint64_t by_payerstat() const { return payer_account + static_cast<uint64_t>(fio_data_type); }
@@ -190,7 +191,8 @@ namespace fioio {
     indexed_by<"byoriginator"_n, const_mem_fun<fiotrxt_info, uint128_t, &fiotrxt_info::by_originator>>,
     indexed_by<"bypayeracct"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_payeracct>>,
     indexed_by<"bypayeeacct"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_payeeacct>>,
-    indexed_by<"bytime"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_time>>,
+    indexed_by<"byobttime"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_obttime>>,
+    indexed_by<"byreqtime"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_reqtime>>,
     indexed_by<"bypayerstat"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_payerstat>>,
     indexed_by<"bypayeestat"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_payeestat>>,
     indexed_by<"bypayerobt"_n, const_mem_fun<fiotrxt_info, uint64_t, &fiotrxt_info::by_payerobt>>,


### PR DESCRIPTION
This is the final version of the hotfix needed once the testnet has been reset to match the mainnet migration status.

**Table name change:**
fiotrxt -> fiotrxt_info

**Data member changes:**
init_time -> req_time
update_time -> obt_time

**New data member:**
req_content
obt_content

**Data member removed:**
content