### PR TITLE
[FIP-1.b] Contracts Part 2: Remove old data from index table (FIO #185)(Old PR #9)

### DIFF
--- a/contracts/fio.address/fio.address.cpp
+++ b/contracts/fio.address/fio.address.cpp
@@ -30,8 +30,6 @@ namespace fioio {
         eosiosystem::producers_table producers;
         eosiosystem::locked_tokens_table lockedTokensTable;
         config appConfig;
-        recordobt_table recordObtTable; //TEMP FOR XFERADDRESS
-        fiorequest_contexts_table fiorequestContextsTable; //TEMP FOR XFERADDRESS
 
     public:
         using contract::contract;
@@ -46,9 +44,7 @@ namespace fioio {
                                                                         voters(SYSTEMACCOUNT, SYSTEMACCOUNT.value),
                                                                         topprods(SYSTEMACCOUNT, SYSTEMACCOUNT.value),
                                                                         producers(SYSTEMACCOUNT, SYSTEMACCOUNT.value),
-                                                                        lockedTokensTable(SYSTEMACCOUNT,SYSTEMACCOUNT.value),
-                                                                        recordObtTable(REQOBTACCOUNT, REQOBTACCOUNT.value), //TEMP FOR XFERADDRESS
-                                                                        fiorequestContextsTable(REQOBTACCOUNT, REQOBTACCOUNT.value){ //TEMP FOR XFERADDRESS
+                                                                        lockedTokensTable(SYSTEMACCOUNT,SYSTEMACCOUNT.value){
             configs_singleton configsSingleton(FeeContract, FeeContract.value);
             appConfig = configsSingleton.get_or_default(config());
         }
@@ -1390,24 +1386,6 @@ namespace fioio {
 
             fio_403_assert(fioname_iter->owner_account == actor.value, ErrorSignature);
             const uint128_t endpoint_hash = string_to_uint128_hash(TRANSFER_ADDRESS_ENDPOINT);
-
-            //TEMP
-            auto obtbyname = recordObtTable.get_index<"bypayee"_n>();
-            auto name_iter = obtbyname.find(nameHash);
-            check(name_iter == obtbyname.end(), "Transfering a FIO address is currently disabled for some fio.addresses");
-
-            auto obtbyname2 = recordObtTable.get_index<"bypayer"_n>();
-            auto name_iter2 = obtbyname2.find(nameHash);
-            check(name_iter2 == obtbyname2.end(), "Transfering a FIO address is currently disabled for some fio.addresses");
-
-            auto reqbyname = fiorequestContextsTable.get_index<"byreceiver"_n>();
-            auto name_iter3 = reqbyname.find(nameHash);
-            check(name_iter3 == reqbyname.end(), "Transfering a FIO address is currently disabled for some fio.addresses");
-
-            auto reqbyname2 = fiorequestContextsTable.get_index<"byoriginator"_n>();
-            auto name_iter4 = reqbyname2.find(nameHash);
-            check(name_iter4 == reqbyname2.end(), "Transfering a FIO address is currently disabled for some fio.addresses");
-            //TEMP
 
             auto fees_by_endpoint = fiofees.get_index<"byendpoint"_n>();
             auto fee_iter = fees_by_endpoint.find(endpoint_hash);


### PR DESCRIPTION
This PR gives the functionality of removing old data from the request and obt index tables. Block producers are able to call `migrtrx` and remove up to 25 records during a single transaction. Added functionality also allows for the API endpoints to use the new data structure introduced in step 1.