### PR TITLE
Reset status migration, copy time_stamp in normal epoch format and reset content 

### DIFF
--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -92,7 +92,7 @@ namespace fioio {
                     auto fioreqctx_iter = trxtByRequestId.find(reqid);
 
                     if( fioreqctx_iter != trxtByRequestId.end() ){
-                        uint64_t timestamp = ( fioreqctx_iter->time_stamp / 1000000 ); // remove the 00000 at the end
+                        uint64_t timestamp = ( statTable->time_stamp / 1000000 ); // remove the 00000 at the end
                         trxtByRequestId.modify(fioreqctx_iter, _self, [&](struct fiotrxt_info &fr) {
                             fr.fio_data_type = statType;
                             fr.obt_time = statTable->time_stamp;

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -122,11 +122,12 @@ namespace fioio {
                             fr.obt_time = timestamp;
                             if (statTable->metadata != "") { fr.obt_content = statTable->metadata; }
                         });
-                        count++;
 
                         mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {
                             strc.currentsta = statTable->id + 1;
                         });
+
+                        count++;
                     }
                     statTable++;
                     if(statTable == fiorequestStatusTable.end()){

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -123,6 +123,10 @@ namespace fioio {
                             if (statTable->metadata != "") { fr.obt_content = statTable->metadata; }
                         });
                         count++;
+
+                        mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {
+                            strc.currentsta = statTable->id + 1;
+                        });
                     }
                     statTable++;
                     if(statTable == fiorequestStatusTable.end()){
@@ -133,11 +137,7 @@ namespace fioio {
                         print(" ALL RECORDS HAVE BEEN COPIED ");
                         return;
                     }
-                    if (count == limit) {
-                        mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {
-                            strc.currentsta = statTable->id + 1;
-                        });
-                        return; }
+                    if (count == limit) { return; }
                 }
             }
         }

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -87,7 +87,7 @@ namespace fioio {
             if (count != limit) {
                 while (trxTable != fioTransactionsTable.end()) { //obt record migrate
                     if(trxTable->fio_data_type == 4) {
-                        uint64_t id = obtTable->id;
+                        uint64_t id = trxTable->id;
 
                         fioTransactionsTable.modify(trxTable, _self, [&](struct fiotrxt_info &strt) {
                             strt.obt_time = trxTable->req_time;

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -303,8 +303,8 @@ namespace fioio {
                 const uint128_t fromHash = string_to_uint128_hash(payer_fio_address.c_str());
                 const string toHashStr = "0x" + to_hex((char *) &toHash, sizeof(toHash));
                 const string fromHashStr = "0x" + to_hex((char *) &fromHash, sizeof(fromHash));
-                const string payerwtimestr = payer_fio_address + to_string(currentTime);
-                const string payeewtimestr = payee_fio_address + to_string(currentTime);
+                const string payerwtimestr = payer_fio_address + to_string(present_time);
+                const string payeewtimestr = payee_fio_address + to_string(present_time);
                 const uint128_t payeewtime = string_to_uint128_hash(payeewtimestr.c_str());
                 const uint128_t payerwtime = string_to_uint128_hash(payerwtimestr.c_str());
 

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -72,6 +72,7 @@ namespace fioio {
             bool isSuccessful = false;
             if (amount > 10) { limit = 10; }
             auto migrTable = mgrStatsTable.begin();
+            auto TrxTable = fioTransactionsTable.begin();
             //reset index for status migration
             if( migrTable->beginobt != 0 ) {
                 mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strd) {
@@ -80,6 +81,11 @@ namespace fioio {
                 });
                 return;
             }
+
+            //iterate fioTransactionsTable
+            // if status == 4
+            // obt_content = req_content
+            // obt_time = req_time
 
             auto statTable = fiorequestStatusTable.find(migrTable->currentsta);
             if (count != limit) { //status table migrate
@@ -326,7 +332,7 @@ namespace fioio {
                         obtinf.payee_fio_addr_hex = toHash;
                         obtinf.obt_content = content;
                         obtinf.fio_data_type = static_cast<int64_t>(trxstatus::obt_action);
-                        obtinf.req_time = present_time;
+                        obtinf.obt_time = present_time;
                         obtinf.payer_fio_addr = payer_fio_address;
                         obtinf.payee_fio_addr = payee_fio_address;
                         obtinf.payee_key = payee_key;

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -86,7 +86,7 @@ namespace fioio {
                 while (statTable != fiorequestStatusTable.end()) {
                     uint64_t reqid = statTable->fio_request_id;
                     uint8_t statType = statTable->status;
-                    uint64_t timestamp = static_cast<uint64>(( statTable->time_stamp / 100000 )); // remove the 00000 at the end
+                    uint64_t timestamp = static_cast<uint64>(( statTable->time_stamp / 1000000 )); // remove the 00000 at the end
                     
                     auto trxtByRequestId = fioTransactionsTable.get_index<"byrequestid"_n>();
                     auto fioreqctx_iter = trxtByRequestId.find(reqid);

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -105,7 +105,7 @@ namespace fioio {
                             strc.currentsta = 0;
                             strc.isFinished = 1;
                         });
-                        print("ALL RECORDS HAVE BEEN COPIED");
+                        print(" ALL RECORDS HAVE BEEN COPIED ");
                         return;
                     }
                     if (count == limit) {

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -72,7 +72,6 @@ namespace fioio {
             bool isSuccessful = false;
             if (amount > 10) { limit = 10; }
             auto migrTable = mgrStatsTable.begin();
-
             //reset index for status migration
             if( migrTable->beginobt != 0 ) {
                 mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strd) {
@@ -98,13 +97,8 @@ namespace fioio {
                             fr.obt_time = statTable->time_stamp;
                             if (statTable->metadata != "") { fr.obt_content = statTable->metadata; }
                         });
-
-                        mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {
-                            strc.currentsta = statTable->id + 1;
-                        });
                         count++;
                     }
-                    // old count
                     statTable++;
                     if(statTable == fiorequestStatusTable.end()){
                         mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {
@@ -115,6 +109,9 @@ namespace fioio {
                         return;
                     }
                     if (count == limit) {
+                        mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {
+                            strc.currentsta = statTable->id + 1;
+                        });
                         return; }
                 }
             }

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -75,7 +75,7 @@ namespace fioio {
             auto migrTable = mgrStatsTable.begin();
 
             //reset index for status migration
-            if( migrTable->currentobt == 990 && migrTable->beginobt != 0 ) { //mainnet current value
+            if( migrTable->beginobt != 0 ) {
                 mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strd) {
                     strd.beginobt = 0;
                     strd.currentsta = 0;
@@ -92,7 +92,7 @@ namespace fioio {
                     auto fioreqctx_iter = trxtByRequestId.find(reqid);
 
                     if( fioreqctx_iter != trxtByRequestId.end() ){
-                        uint64_t timestamp = ( statTable->time_stamp / 1000000 ); // remove the 00000 at the end
+                        uint64_t timestamp = ( statTable->time_stamp / 100000 ); // remove the 00000 at the end
                         trxtByRequestId.modify(fioreqctx_iter, _self, [&](struct fiotrxt_info &fr) {
                             fr.fio_data_type = statType;
                             fr.obt_time = statTable->time_stamp;
@@ -104,6 +104,7 @@ namespace fioio {
                         });
                         count++;
                     }
+                    // old count
                     statTable++;
                     if(statTable == fiorequestStatusTable.end()){
                         mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {
@@ -256,6 +257,7 @@ namespace fioio {
             //end fees, bundle eligible fee logic
 
             if (fio_request_id.length() > 0) {
+                uint64_t currentTime = current_time();
                 uint64_t requestId;
                 requestId = std::atoi(fio_request_id.c_str());
 
@@ -295,7 +297,7 @@ namespace fioio {
                     fr.fio_request_id = requestId;
                     fr.status = static_cast<int64_t >(trxstatus::sent_to_blockchain);
                     fr.metadata = content;
-                    fr.time_stamp = present_time;
+                    fr.time_stamp = currentTime;
                 });
             } else {
                 const uint64_t id = recordObtTable.available_primary_key();
@@ -303,8 +305,8 @@ namespace fioio {
                 const uint128_t fromHash = string_to_uint128_hash(payer_fio_address.c_str());
                 const string toHashStr = "0x" + to_hex((char *) &toHash, sizeof(toHash));
                 const string fromHashStr = "0x" + to_hex((char *) &fromHash, sizeof(fromHash));
-                const string payerwtimestr = payer_fio_address + to_string(present_time);
-                const string payeewtimestr = payee_fio_address + to_string(present_time);
+                const string payerwtimestr = payer_fio_address + to_string(currentTime);
+                const string payeewtimestr = payee_fio_address + to_string(currentTime);
                 const uint128_t payeewtime = string_to_uint128_hash(payeewtimestr.c_str());
                 const uint128_t payerwtime = string_to_uint128_hash(payerwtimestr.c_str());
 
@@ -354,7 +356,7 @@ namespace fioio {
                     obtinf.payer_fio_address_with_time = payerwtime;
                     obtinf.payee_fio_address_with_time = payeewtime;
                     obtinf.content = content;
-                    obtinf.time_stamp = present_time;
+                    obtinf.time_stamp = currentTime;
                     obtinf.payer_fio_addr = payer_fio_address;
                     obtinf.payee_fio_addr = payee_fio_address;
                     obtinf.payee_key = payee_key;

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -97,8 +97,8 @@ namespace fioio {
                         mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {
                             strc.currentobt = id + 1;
                         });
+                        count++;
                     }
-                    count++;
                     if (count == limit) { return; }
                     trxTable++;
                 }

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -86,7 +86,7 @@ namespace fioio {
             auto trxTable = fioTransactionsTable.find(migrTable->currentobt);
             if (count != limit) {
                 while (trxTable != fioTransactionsTable.end()) { //obt record migrate
-                    if(trxTable->fio_data_type == 4) {
+                    if(trxTable->fio_data_type == 4 && trxTable->obt_content == "") {
                         uint64_t id = trxTable->id;
 
                         fioTransactionsTable.modify(trxTable, _self, [&](struct fiotrxt_info &strt) {

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -71,7 +71,6 @@ namespace fioio {
             uint16_t count = 0;
             bool isSuccessful = false;
             if (amount > 10) { limit = 10; }
-            auto trxTable = fioTransactionsTable.begin();
             auto migrTable = mgrStatsTable.begin();
 
             //reset index for status migration
@@ -88,11 +87,12 @@ namespace fioio {
                 while (statTable != fiorequestStatusTable.end()) {
                     uint64_t reqid = statTable->fio_request_id;
                     uint8_t statType = statTable->status;
+                    uint64_t timestamp = ( statTable->time_stamp / 100000 ); // remove the 00000 at the end
+                    
                     auto trxtByRequestId = fioTransactionsTable.get_index<"byrequestid"_n>();
                     auto fioreqctx_iter = trxtByRequestId.find(reqid);
 
                     if( fioreqctx_iter != trxtByRequestId.end() ){
-                        uint64_t timestamp = ( statTable->time_stamp / 100000 ); // remove the 00000 at the end
                         trxtByRequestId.modify(fioreqctx_iter, _self, [&](struct fiotrxt_info &fr) {
                             fr.fio_data_type = statType;
                             fr.obt_time = statTable->time_stamp;

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -305,8 +305,8 @@ namespace fioio {
                 const uint128_t fromHash = string_to_uint128_hash(payer_fio_address.c_str());
                 const string toHashStr = "0x" + to_hex((char *) &toHash, sizeof(toHash));
                 const string fromHashStr = "0x" + to_hex((char *) &fromHash, sizeof(fromHash));
-                const string payerwtimestr = payer_fio_address + to_string(currentTime);
-                const string payeewtimestr = payee_fio_address + to_string(currentTime);
+                const string payerwtimestr = payer_fio_address + to_string(present_time);
+                const string payeewtimestr = payee_fio_address + to_string(present_time);
                 const uint128_t payeewtime = string_to_uint128_hash(payeewtimestr.c_str());
                 const uint128_t payerwtime = string_to_uint128_hash(payerwtimestr.c_str());
 
@@ -356,7 +356,7 @@ namespace fioio {
                     obtinf.payer_fio_address_with_time = payerwtime;
                     obtinf.payee_fio_address_with_time = payeewtime;
                     obtinf.content = content;
-                    obtinf.time_stamp = currentTime;
+                    obtinf.time_stamp = present_time;
                     obtinf.payer_fio_addr = payer_fio_address;
                     obtinf.payee_fio_addr = payee_fio_address;
                     obtinf.payee_key = payee_key;

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -86,13 +86,15 @@ namespace fioio {
             auto trxTable = fioTransactionsTable.find(migrTable->currentobt);
             if (count != limit) {
                 while (trxTable != fioTransactionsTable.end()) { //obt record migrate
-                    if(trxTable->fio_data_type == 4 && trxTable->obt_content == "") {
+                    if(trxTable->fio_data_type == 4 && trxTable->obt_time == 0) {
                         uint64_t id = trxTable->id;
                         uint64_t time = trxTable->req_time;
+                        string content = trxTable->req_content;
+                        if( content == "" ) { content = trxTable->obt_content; }
 
                         fioTransactionsTable.modify(trxTable, _self, [&](struct fiotrxt_info &strt) {
                             strt.obt_time = time;
-                            strt.obt_content = trxTable->req_content;
+                            strt.obt_content = content;
                             strt.req_content = "";
                             strt.req_time = 0;
                         });

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -94,7 +94,7 @@ namespace fioio {
                     if( fioreqctx_iter != trxtByRequestId.end() ){
                         trxtByRequestId.modify(fioreqctx_iter, _self, [&](struct fiotrxt_info &fr) {
                             fr.fio_data_type = statType;
-                            fr.obt_time = statTable->time_stamp;
+                            fr.obt_time = timestamp;
                             if (statTable->metadata != "") { fr.obt_content = statTable->metadata; }
                         });
                         count++;

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -86,7 +86,7 @@ namespace fioio {
             auto trxTable = fioTransactionsTable.find(migrTable->currentobt);
             if (count != limit) {
                 while (trxTable != fioTransactionsTable.end()) { //obt record migrate
-                    if(trxTable->fio_data_type == trxstatus::obt_action) {
+                    if(trxTable->fio_data_type == 4) {
                         uint64_t id = obtTable->id;
 
                         fioTransactionsTable.modify(trxTable, _self, [&](struct fiotrxt_info &strt) {

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -88,9 +88,10 @@ namespace fioio {
                 while (trxTable != fioTransactionsTable.end()) { //obt record migrate
                     if(trxTable->fio_data_type == 4 && trxTable->obt_content == "") {
                         uint64_t id = trxTable->id;
+                        uint64_t time = trxTable->req_time;
 
                         fioTransactionsTable.modify(trxTable, _self, [&](struct fiotrxt_info &strt) {
-                            strt.obt_time = trxTable->req_time;
+                            strt.obt_time = time;
                             strt.obt_content = trxTable->req_content;
                             strt.req_content = "";
                             strt.req_time = 0;

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -86,7 +86,6 @@ namespace fioio {
             auto statTable = fiorequestStatusTable.find(migrTable->currentsta);
             if (count != limit) { //status table migrate
                 while (statTable != fiorequestStatusTable.end()) {
-                    uint64_t id = fioreqctx_iter->id;
                     uint64_t reqid = statTable->fio_request_id;
                     uint8_t statType = statTable->status;
                     uint64_t timestamp = ( statType->time_stamp / 1000000 ); // remove the 00000 at the end

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -86,7 +86,7 @@ namespace fioio {
                 while (statTable != fiorequestStatusTable.end()) {
                     uint64_t reqid = statTable->fio_request_id;
                     uint8_t statType = statTable->status;
-                    uint64_t timestamp = static_cast<uint64>(( statTable->time_stamp / 1000000 )); // remove the 00000 at the end
+                    uint64_t timestamp = static_cast<uint64_t>(( statTable->time_stamp / 1000000 )); // remove the 00000 at the end
                     
                     auto trxtByRequestId = fioTransactionsTable.get_index<"byrequestid"_n>();
                     auto fioreqctx_iter = trxtByRequestId.find(reqid);

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -86,7 +86,7 @@ namespace fioio {
                 while (statTable != fiorequestStatusTable.end()) {
                     uint64_t reqid = statTable->fio_request_id;
                     uint8_t statType = statTable->status;
-                    uint64_t timestamp = ( statTable->time_stamp / 100000 ); // remove the 00000 at the end
+                    uint64_t timestamp = static_cast<uint64>(( statTable->time_stamp / 100000 )); // remove the 00000 at the end
                     
                     auto trxtByRequestId = fioTransactionsTable.get_index<"byrequestid"_n>();
                     auto fioreqctx_iter = trxtByRequestId.find(reqid);

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -92,6 +92,8 @@ namespace fioio {
                         fioTransactionsTable.modify(trxTable, _self, [&](struct fiotrxt_info &strt) {
                             strt.obt_time = trxTable->req_time;
                             strt.obt_content = trxTable->req_content;
+                            strt.req_content = "";
+                            strt.req_time = 0;
                         });
 
                         mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -88,11 +88,11 @@ namespace fioio {
                 while (statTable != fiorequestStatusTable.end()) {
                     uint64_t reqid = statTable->fio_request_id;
                     uint8_t statType = statTable->status;
-                    uint64_t timestamp = ( statType->time_stamp / 1000000 ); // remove the 00000 at the end
                     auto trxtByRequestId = fioTransactionsTable.get_index<"byrequestid"_n>();
                     auto fioreqctx_iter = trxtByRequestId.find(reqid);
 
                     if( fioreqctx_iter != trxtByRequestId.end() ){
+                        uint64_t timestamp = ( fioreqctx_iter->time_stamp / 1000000 ); // remove the 00000 at the end
                         trxtByRequestId.modify(fioreqctx_iter, _self, [&](struct fiotrxt_info &fr) {
                             fr.fio_data_type = statType;
                             fr.obt_time = statTable->time_stamp;


### PR DESCRIPTION
This PR fixes multiple issues related to the migration of request and obt records. 

- Iteration bug causing mainnet to timeout due to large gaps in status updates needing to be migrated.  
- Status timestamps were originally stored incorrectly. This caused trailing 0s that needed to be removed. 
- `req_timestamp` data needed to be transferred to `obt_timestamp` on statuses with `obt_action`
- `req_content` data needed to be transferred to `obt_content`on statuses with `obt_action`
- multiple corrects to `recordobt` to store these values in the future correctly.