### PR TITLE
Scope migration iteration into smaller sets for more optimized indexing. 

### DIFF
--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -140,7 +140,7 @@ namespace fioio {
                     }
                     if (count == limit) {
                         mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {
-                            strc.currentsta = statTable->id + 1;
+                            strc.currentsta = statTable->id;
                         });
                         return;
                     }

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -98,13 +98,15 @@ namespace fioio {
                             strt.req_content = "";
                             strt.req_time = 0;
                         });
+                    }
+                    count++;
 
+                    if (count == limit) {
                         mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {
                             strc.currentobt = id + 1;
                         });
-                        count++;
+                        return;
                     }
-                    if (count == limit) { return; }
                     trxTable++;
                 }
             }
@@ -125,11 +127,6 @@ namespace fioio {
                             fr.obt_time = timestamp;
                             if (statTable->metadata != "") { fr.obt_content = statTable->metadata; }
                         });
-
-                        mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {
-                            strc.currentsta = statTable->id + 1;
-                        });
-
                         count++;
                     }
                     statTable++;
@@ -141,7 +138,12 @@ namespace fioio {
                         print(" ALL RECORDS HAVE BEEN COPIED ");
                         return;
                     }
-                    if (count == limit) { return; }
+                    if (count == limit) {
+                        mgrStatsTable.modify(migrTable, _self, [&](struct migrledger &strc) {
+                            strc.currentsta = statTable->id + 1;
+                        });
+                        return;
+                    }
                 }
             }
         }

--- a/contracts/fio.request.obt/fio.request.obt.cpp
+++ b/contracts/fio.request.obt/fio.request.obt.cpp
@@ -86,8 +86,8 @@ namespace fioio {
             auto trxTable = fioTransactionsTable.find(migrTable->currentobt);
             if (count != limit) {
                 while (trxTable != fioTransactionsTable.end()) { //obt record migrate
+                    uint64_t id = trxTable->id;
                     if(trxTable->fio_data_type == 4 && trxTable->obt_time == 0) {
-                        uint64_t id = trxTable->id;
                         uint64_t time = trxTable->req_time;
                         string content = trxTable->req_content;
                         if( content == "" ) { content = trxTable->obt_content; }


### PR DESCRIPTION
We noticed while migrating testnet timestamp data that it was possible to have large gaps of iteration index searches that had the possibility of timing out the transaction and taking longer than the approved transaction times. 