### PR TITLE
FIP-21 staking -- resolve BD-2755, also set release date for ROE computation, clean up ABI and set init of global state vars to 0

### DIFF
--- a/contracts/fio.staking/fio.staking.abi
+++ b/contracts/fio.staking/fio.staking.abi
@@ -54,70 +54,6 @@
                                 }
                              ]
                },{
-                   "name": "decgstake",
-                   "base": "",
-                   "fields": [
-                      {
-                        "name": "fiostakedsufs",
-                        "type": "int64"
-                      },
-                      {
-                         "name": "fiorewardedsufs",
-                         "type": "int64"
-                      },
-                      {
-                        "name": "srpcountsus",
-                        "type": "int64"
-                      }
-                   ]
-               },{
-                   "name": "incgstake",
-                   "base": "",
-                   "fields": [
-                      {
-                         "name": "fiostakedsufs",
-                         "type": "int64"
-                      },
-                      {
-                         "name": "srpcountsus",
-                         "type": "int64"
-                      }
-                   ]
-               },{
-                   "name": "incacctstake",
-                   "base": "",
-                   "fields": [
-                      {
-                         "name": "owner",
-                         "type": "name"
-                      },
-                      {
-                         "name": "fiostakedsufs",
-                         "type": "int64"
-                      },
-                      {
-                         "name": "srpaawardedsus",
-                         "type": "int64"
-                      }
-                   ]
-               },{
-                   "name": "decacctstake",
-                   "base": "",
-                   "fields": [
-                      {
-                         "name": "owner",
-                         "type": "name"
-                      },
-                      {
-                         "name": "fiostakedsufs",
-                         "type": "int64"
-                      },
-                      {
-                         "name": "srprewardedsus",
-                         "type": "int64"
-                      }
-                   ]
-               },{
                    "name": "stakefio",
                    "base": "",
                    "fields": [
@@ -171,26 +107,6 @@
           ],
     "types": [],
     "actions": [
-                 {
-                    "name": "decgstake",
-                    "type": "decgstake",
-                    "ricardian_contract": ""
-                 },
-                 {
-                    "name": "incgstake",
-                    "type": "incgstake",
-                    "ricardian_contract": ""
-                 },
-                 {
-                    "name": "incacctstake",
-                    "type": "incacctstake",
-                    "ricardian_contract": ""
-                 },
-                 {
-                    "name": "decacctstake",
-                    "type": "decacctstake",
-                    "ricardian_contract": ""
-                 },
                  {
                     "name": "stakefio",
                     "type": "stakefio",

--- a/contracts/fio.staking/fio.staking.cpp
+++ b/contracts/fio.staking/fio.staking.cpp
@@ -13,6 +13,8 @@
 #include <fio.fee/fio.fee.hpp>
 #include <fio.system/include/fio.system/fio.system.hpp>
 
+#define ENABLESTAKINGREWARDSEPOCHSEC  1627686000  //July 30 5:00PM MST 11:00PM GMT
+
 namespace fioio {
 
 class [[eosio::contract("Staking")]]  Staking: public eosio::contract {
@@ -97,6 +99,7 @@ public:
                          const string &tpid, const name &actor) {
         //signer not actor.
         require_auth(actor);
+        const uint32_t present_time = now();
 
         if(debugout) {
             print(" calling stakefio fio address ", fio_address);
@@ -121,7 +124,7 @@ public:
             fio_403_assert(fioname_iter->owner_account == actor.value, ErrorSignature);
 
             const uint32_t expiration = fioname_iter->expiration;
-            const uint32_t present_time = now();
+
             fio_400_assert(present_time <= expiration, "fio_address", fio_address, "FIO Address expired. Renew first.",
                            ErrorDomainExpired);
             bundleeligiblecountdown = fioname_iter->bundleeligiblecountdown;
@@ -240,7 +243,8 @@ public:
 
         //compute rate of exchange
         uint64_t rateofexchange =  1000000000;
-        if (gstaking.combined_token_pool >= COMBINEDTOKENPOOLMINIMUM) {
+
+        if ((gstaking.combined_token_pool >= COMBINEDTOKENPOOLMINIMUM) && (present_time > ENABLESTAKINGREWARDSEPOCHSEC)) {
             if(debugout) {
                 print(" global srp count ", gstaking.global_srp_count);
                 print(" combined_token_pool ", gstaking.combined_token_pool);
@@ -411,7 +415,7 @@ public:
         }
         //compute rate of exchange
         uint64_t rateofexchange =  1000000000;
-        if (gstaking.combined_token_pool >= COMBINEDTOKENPOOLMINIMUM) {
+        if ((gstaking.combined_token_pool >= COMBINEDTOKENPOOLMINIMUM) && (present_time > ENABLESTAKINGREWARDSEPOCHSEC)) {
             if(debugout) {
                 print(" global srp count ", gstaking.global_srp_count);
                 print(" combined_token_pool ", gstaking.combined_token_pool);

--- a/contracts/fio.staking/fio.staking.hpp
+++ b/contracts/fio.staking/fio.staking.hpp
@@ -21,11 +21,11 @@ namespace fioio {
     struct [[eosio::table("staking"), eosio::contract("fio.staking")]] global_staking_state {
         global_staking_state(){}
         uint64_t staked_token_pool = 0;   //total FIO tokens staked for all accounts, units sufs.
-        uint64_t combined_token_pool = 1;  //total fio tokens staked for all accounts plus fio rewards all accounts, units SUFs,
+        uint64_t combined_token_pool = 0;  //total fio tokens staked for all accounts plus fio rewards all accounts, units SUFs,
         // incremented by the staked amount when user stakes, when tokens are earmarked as staking rewards,
         // decremented by unstaked amount + reward amount when users unstake
         uint64_t rewards_token_pool = 0; //total counter how much has come in from fees AND minting units SUFs
-        uint64_t global_srp_count = 1;  // units SUS, total SRP for all FIO users, increment when users stake, decrement when users unstake.
+        uint64_t global_srp_count = 0;  // units SUS, total SRP for all FIO users, increment when users stake, decrement when users unstake.
         uint64_t daily_staking_rewards = 0; //this is used to track the daily staking rewards collected from fees,
         // its used only to determine if the protocol should mint FIO whe rewards are under the DAILYSTAKINGMINTTHRESHOLD
         uint64_t staking_rewards_reserves_minted = 0; //the total amount of FIO used in minting rewards tokens, will not exceed STAKINGREWARDSRESERVEMAXIMUM

--- a/contracts/fio.system/include/fio.system/fio.system.hpp
+++ b/contracts/fio.system/include/fio.system/fio.system.hpp
@@ -167,11 +167,11 @@ struct lockperiodv2 {
 struct [[eosio::table, eosio::contract("fio.system")]] locked_tokens_info_v2 {
     int64_t id; //this is the identifier of the lock, primary key
     name owner_account; //this is the account that owns the lock, secondary key
-    int64_t lock_amount = 0; //this is the amount of the lock in FIO SUF
-    int32_t payouts_performed = 0; //this is the number of payouts performed thus far.
+    uint64_t lock_amount = 0; //this is the amount of the lock in FIO SUF
+    uint32_t payouts_performed = 0; //this is the number of payouts performed thus far.
     int32_t can_vote = 0; //this is the flag indicating if the lock is votable/proxy-able
     std::vector<lockperiodv2> periods;// this is the locking periods for the lock
-    int64_t remaining_lock_amount = 0; //this is the amount remaining in the lock in FIO SUF, get decremented as unlocking occurs.
+    uint64_t remaining_lock_amount = 0; //this is the amount remaining in the lock in FIO SUF, get decremented as unlocking occurs.
     uint32_t timestamp = 0; //this is the time of creation of the lock, locking periods are relative to this time.
 
     uint64_t primary_key() const { return id; }

--- a/contracts/fio.token/src/fio.token.cpp
+++ b/contracts/fio.token/src/fio.token.cpp
@@ -457,11 +457,11 @@ namespace eosio {
                              const name &actor,
                              const string &tpid) {
 
-        fio_400_assert(((periods.size()) >= 1 && (periods.size() <= 365)), "unlock_periods", "Invalid unlock periods",
+        fio_400_assert(((periods.size()) >= 1 && (periods.size() <= 50)), "unlock_periods", "Invalid unlock periods",
                        "Invalid number of unlock periods", ErrorTransactionTooLarge);
         uint64_t tota = 0;
         double tv = 0.0;
-        int64_t longestperiod = 0;
+
         for(int i=0;i<periods.size();i++){
             fio_400_assert(periods[i].amount > 0, "unlock_periods", "Invalid unlock periods",
                            "Invalid amount value in unlock periods", ErrorInvalidUnlockPeriods);
@@ -472,10 +472,8 @@ namespace eosio {
                 fio_400_assert(periods[i].duration > periods[i-1].duration, "unlock_periods", "Invalid unlock periods",
                                "Invalid duration value in unlock periods, must be sorted", ErrorInvalidUnlockPeriods);
             }
-            if (periods[i].duration > longestperiod){
-                longestperiod = periods[i].duration;
-            }
         }
+
         fio_400_assert(tota == amount, "unlock_periods", "Invalid unlock periods",
                        "Invalid total amount for unlock periods", ErrorInvalidUnlockPeriods);
 
@@ -500,8 +498,9 @@ namespace eosio {
         fio_400_assert(max_fee >= reg_amount, "max_fee", to_string(max_fee), "Fee exceeds supplied maximum.",
                        ErrorMaxFeeExceeded);
 
-        int64_t ninetydayperiods = longestperiod / (SECONDSPERDAY * 90);
-        int64_t rem = longestperiod % (SECONDSPERDAY * 90);
+
+        int64_t ninetydayperiods = periods[periods.size()-1].duration / (SECONDSPERDAY * 90);
+        int64_t rem = periods[periods.size()-1].duration % (SECONDSPERDAY * 90);
         if (rem > 0){
             ninetydayperiods++;
         }


### PR DESCRIPTION
resolve 2755, logic errors when payouts is 0 and general lock periods are removed
because they are in the past during lock adaptation at unstaking, logic error when a period is not yet paid/unlocked but the lock period is in the past during lock adaptation at unstake. 

add a release date to ROE calculation before which the ROE will remain 1.

reduce the max number of general lock periods to become 50 for trnsloctoks

this was tested by changing the ROE to be in the past,
then running the stake-rewards-dev-tests.js to verify ROE is computed
then mod the release date to be in teh future,
rerun the tests and see ROE remains 1 and Rewards are not given as a result.


clean up ABI and init global state vars to 0

this was dev tested using several of the staking tests available in fio.test.

fio.test must be updated for all tests using ROE and rewards.
for all tests that use ROE and rewards
go to the contract file fio.staking.cpp
modify the following line
#define ENABLESTAKINGREWARDSEPOCHSEC  1627686000  //July 30 5:00PM MST 11:00PM GMT
to be the desired release date in epochseconds, set to the future to see that the ROE remains 1, and staking awards are not awarded.
set to the past to see that ROE is set to values as appropriate once the 1M threshold is reached, and also that awards are awarded....
set this value then rebuild the contracts and then run desired tests...
FOR FIO repo
go to the chain_plugin.cpp around line 2738
change the following line
const int32_t ENABLESTAKINGREWARDSEPOCHSEC = 1627686000;  //July 30 5:00PM MST 11:00PM GMT
to be the desired release date in epochseconds, set to the future to see that the ROE remains 1,
set to the past to see that ROE is set to values as appropriate once the 1M threshold is reached,
rebuild the fio repo then run the desired tests.....
let me know if you have any questions.....
