### PR TITLE
Use safer integer arithmetic in bpclaim

### DIFF
--- a/contracts/fio.treasury/fio.treasury.cpp
+++ b/contracts/fio.treasury/fio.treasury.cpp
@@ -303,8 +303,8 @@ public:
 
                         if (bpcount <= MAXACTIVEBPS) abpcount = bpcount;
                         auto bprewardstat = bprewards.get();
-                        uint64_t tostandbybps = static_cast<uint64_t>(bprewardstat.rewards * .60);
-                        uint64_t toactivebps = static_cast<uint64_t>(bprewardstat.rewards * .40);
+                        uint64_t tostandbybps = static_cast<uint64_t>((bprewardstat.rewards / 10) * 6);
+                        uint64_t toactivebps = static_cast<uint64_t>((bprewardstat.rewards / 10) * 4);
 
                         bpcounter = 0;
                         auto votesharesiter = voteshares.get_index<"byvotes"_n>();
@@ -361,7 +361,7 @@ public:
                                    make_tuple(producer)
                                 ).send();
                         }
-                        
+
                         // PAY FOUNDATION //
                         auto fdtnstate = fdtnrewards.get();
                         if(fdtnstate.rewards > 0) {


### PR DESCRIPTION
This changes some math for the standby and active bp reward distribution to prevent overflow during the operation.


BPClaim test steps

- Start new dev environment from develop
- Vote for the producer
~/fio/3.0/bin/clio -u http://localhost:8889 push action -j eosio voteproducer '{"producers":["bp1@dapixdev"],"fio_address":"adam@dapixdev","actor":"htjonrkf1lgs","max_fee":"40000000000"}' -p htjonrkf1lgs@active

- Stake some FIO
~/fio/3.0/bin/clio -u http://localhost:8889 push action -j fio.staking stakefio '{"fio_address":"adam@dapixdev","amount":1000000000,"max_fee":400000000000, "tpid":"","actor":"htjonrkf1lgs"}' -p htjonrkf1lgs@active
- use the htjonrkf1lgs account as foundation account in fio.common/fio.accounts.hpp
L37:     static const name FOUNDATIONACCOUNT = name("htjonrkf1lgs");
- run bpclaim
 ~/fio/3.0/bin/clio -u http://localhost:8889 push action -j fio.treasury bpclaim '{"fio_address":"bp1@dapixdev","actor":"qbxn5zhw2ypw"}' -p qbxn5zhw2ypw@active

Results from original dev test:
Following these steps,
- Minted amounts remained unchanged
- Payouts to single producer account from treasury remained unchanged