### PR TITLE
FIP-21  add activated flag staking rewards,  handle edge condition in lock adaptation, reduce stake unstake RAM bump

### DIFF
--- a/contracts/fio.common/fio.common.hpp
+++ b/contracts/fio.common/fio.common.hpp
@@ -459,8 +459,8 @@ namespace fioio {
     static const uint64_t INITIALACCOUNTRAM  = 25600;
     static const uint64_t ADDITIONALRAMBPDESCHEDULING = 25600;
 
-    static const uint64_t STAKEFIOTOKENSRAM = 1024; //integrated.
-    static const uint64_t UNSTAKEFIOTOKENSRAM = 1024; //integrated.
+    static const uint64_t STAKEFIOTOKENSRAM = 256; //integrated.
+    static const uint64_t UNSTAKEFIOTOKENSRAM = 256; //integrated.
     static const uint64_t REGDOMAINRAM  = 2560;  //integrated.
     static const uint64_t REGADDRESSRAM = 2560; //integrated.
     static const uint64_t ADDADDRESSRAM = 512; //integrated.

--- a/contracts/fio.staking/fio.staking.abi
+++ b/contracts/fio.staking/fio.staking.abi
@@ -30,6 +30,10 @@
                                 {
                                     "name": "staking_rewards_reserves_minted",
                                     "type": "uint64"
+                                },
+                                {
+                                    "name": "staking_rewards_activated",
+                                    "type": "int64"
                                 }
                             ]
                },{

--- a/contracts/fio.staking/fio.staking.hpp
+++ b/contracts/fio.staking/fio.staking.hpp
@@ -29,10 +29,11 @@ namespace fioio {
         uint64_t daily_staking_rewards = 0; //this is used to track the daily staking rewards collected from fees,
         // its used only to determine if the protocol should mint FIO whe rewards are under the DAILYSTAKINGMINTTHRESHOLD
         uint64_t staking_rewards_reserves_minted = 0; //the total amount of FIO used in minting rewards tokens, will not exceed STAKINGREWARDSRESERVEMAXIMUM
+        int64_t staking_rewards_activated = 0; //this flag indicates that the staking rewards has crossed the startup threshold.
 
         EOSLIB_SERIALIZE( global_staking_state,(staked_token_pool)
                 (combined_token_pool)(rewards_token_pool)(global_srp_count)
-                (daily_staking_rewards)(staking_rewards_reserves_minted)
+                (daily_staking_rewards)(staking_rewards_reserves_minted)(staking_rewards_activated)
         )
     };
 


### PR DESCRIPTION
lock adaptation needs to consider that a period might be paid out, and when this is the case DO NOT use this period as the insert period. Add an activation flag for staking rewards computation, once the threshold is crossed then rewards are activated in the protocol and always computed thereafter.

modify ram bump on stake and unstake to become 256. 