### PR TITLE
FIP-21 staking -- remove rounding at 10th digit, init global srps to 1

### DIFF
--- a/contracts/fio.staking/fio.staking.cpp
+++ b/contracts/fio.staking/fio.staking.cpp
@@ -465,7 +465,7 @@ public:
         }
 
         //revise
-        const string message = "unstakefio, srps to claim "+ to_string(srpstoclaim) + " rate of exchange "+ roesufspersrp +
+        const string message = "unstakefio, srps to claim "+ to_string(srpstoclaim) +
                                " srpsclaimed " + to_string(sufclaimed) + " amount "+ to_string(amount) + " srpsclaimed must be >= amount. "
                                                                                                           " must be greater than or equal srpstoclaim " + to_string(srpstoclaim) ;
         if (debugout) {

--- a/contracts/fio.staking/fio.staking.cpp
+++ b/contracts/fio.staking/fio.staking.cpp
@@ -251,7 +251,8 @@ public:
             }
             roesufspersrp = (long double)(gstaking.combined_token_pool) / (long double)(gstaking.global_srp_count);
             //round it after the 9th decimal place
-            roesufspersrp = roundl(roesufspersrp * 1000000000.0) / 1000000000.0;
+            //commented out do not round, preserve the precision of this value
+           // roesufspersrp = roundl(roesufspersrp * 1000000000.0) / 1000000000.0;
             if (debugout) {
                 print(" rate of exchange set to ", roesufspersrp,"\n");
             }
@@ -444,7 +445,8 @@ public:
             }
             roesufspersrp = (long double)(gstaking.combined_token_pool) / (long double)(gstaking.global_srp_count);
             //round it after the 9th decimal place
-            roesufspersrp = roundl(roesufspersrp * 1000000000.0) / 1000000000.0;
+            // commented out do not round, preserve the precision of this value
+           // roesufspersrp = roundl(roesufspersrp * 1000000000.0) / 1000000000.0;
             if (debugout) {
                 print(" rate of exchange set to ", roesufspersrp,"\n");
             }

--- a/contracts/fio.staking/fio.staking.cpp
+++ b/contracts/fio.staking/fio.staking.cpp
@@ -250,6 +250,8 @@ public:
                 print(" staked_token_pool ", gstaking.staked_token_pool,"\n");
             }
             roesufspersrp = (long double)(gstaking.combined_token_pool) / (long double)(gstaking.global_srp_count);
+            //round it after the 9th decimal place
+            roesufspersrp = roundl(roesufspersrp * 1000000000.0) / 1000000000.0;
             if (debugout) {
                 print(" rate of exchange set to ", roesufspersrp,"\n");
             }
@@ -441,6 +443,8 @@ public:
                 print(" staked_token_pool ", gstaking.staked_token_pool,"\n");
             }
             roesufspersrp = (long double)(gstaking.combined_token_pool) / (long double)(gstaking.global_srp_count);
+            //round it after the 9th decimal place
+            roesufspersrp = roundl(roesufspersrp * 1000000000.0) / 1000000000.0;
             if (debugout) {
                 print(" rate of exchange set to ", roesufspersrp,"\n");
             }
@@ -461,7 +465,7 @@ public:
         }
 
         //revise
-        const string message = "unstakefio, srps to claim "+ to_string(srpstoclaim) + " rate of exchange "+ to_string(roesufspersrp) +
+        const string message = "unstakefio, srps to claim "+ to_string(srpstoclaim) + " rate of exchange "+ roesufspersrp +
                                " srpsclaimed " + to_string(sufclaimed) + " amount "+ to_string(amount) + " srpsclaimed must be >= amount. "
                                                                                                           " must be greater than or equal srpstoclaim " + to_string(srpstoclaim) ;
         if (debugout) {

--- a/contracts/fio.staking/fio.staking.cpp
+++ b/contracts/fio.staking/fio.staking.cpp
@@ -269,7 +269,7 @@ public:
             print("the value of combined_token_pool before state inc in stake: ",gstaking.combined_token_pool,"\n" );
         }
 
-        uint64_t srpstoaward = (uint64_t) truncl(t1);
+        uint64_t srpstoaward = (uint64_t) roundl(t1);
 
         //update global staking state
         gstaking.combined_token_pool += amount;
@@ -427,7 +427,7 @@ public:
          //  this needs to be a floating point (double) operation
        //round this to avoid issues with decimal representations
        double t1 = (((double)astakeiter->total_srp * (double)( (double)amount / (double)astakeiter->total_staked_fio)));
-        uint64_t srpstoclaim = (uint64_t)trunc(t1);
+        uint64_t srpstoclaim = (uint64_t)round(t1);
 
         if (debugout) {
             print(" the long double result of the srpstoclaim is : ",t1,"\n");
@@ -458,7 +458,8 @@ public:
 
         long double t2 = ((long double)(srpstoclaim) * roesufspersrp);
 
-        uint64_t sufclaimed = (uint64_t)truncl(t2);
+
+        uint64_t sufclaimed = (uint64_t)roundl(t2);
         if (debugout){
             print("the long double of sufclaimed is : ",t2,"\n");
             print("the value of sufclaimed is : ",sufclaimed,"\n");

--- a/contracts/fio.staking/fio.staking.hpp
+++ b/contracts/fio.staking/fio.staking.hpp
@@ -25,7 +25,7 @@ namespace fioio {
         // incremented by the staked amount when user stakes, when tokens are earmarked as staking rewards,
         // decremented by unstaked amount + reward amount when users unstake
         uint64_t rewards_token_pool = 0; //total counter how much has come in from fees units SUFs
-        uint64_t global_srp_count = 0;  // units SUS, total SRP for all FIO users, increment when users stake, decrement when users unstake.
+        uint64_t global_srp_count = 1;  // units SUS, total SRP for all FIO users, increment when users stake, decrement when users unstake.
         uint64_t daily_staking_rewards = 0; //this is used to track the daily staking rewards collected from fees,
         // its used only to determine if the protocol should mint FIO whe rewards are under the DAILYSTAKINGMINTTHRESHOLD
         uint64_t staking_rewards_reserves_minted = 0; //the total amount of FIO used in minting rewards tokens, will not exceed STAKINGREWARDSRESERVEMAXIMUM


### PR DESCRIPTION
remove the use of rounding of the 10th digit in internal calls, 
init the value of global srps to be 1 to help protect against div by 0