### PR TITLE
FIP-27 fixes

### DIFF
--- a/contracts/fio.address/fio.address.cpp
+++ b/contracts/fio.address/fio.address.cpp
@@ -1450,7 +1450,7 @@ namespace fioio {
                                                                     string(nftobj->token_id.c_str()) +
                                                                     string(nftobj->chain_code.c_str())));
 
-                fio_400_assert(nft_iter == nftbyid.end(), "fio_address", fio_address, "NFT not currently mapped",
+                fio_400_assert(nft_iter != nftbyid.end(), "fio_address", fio_address, "NFT not currently mapped",
                             ErrorInvalidValue);
 
                 if (nft_iter != nftbyid.end()) {

--- a/contracts/fio.address/fio.address.cpp
+++ b/contracts/fio.address/fio.address.cpp
@@ -1328,7 +1328,7 @@ namespace fioio {
 
             uint64_t fee_amount = 0;
 
-            if (fioname_iter->bundleeligiblecountdown > 2) {
+            if (fioname_iter->bundleeligiblecountdown > 1) {
                 action{
                         permission_level{_self, "active"_n},
                         AddressContract,

--- a/contracts/fio.address/fio.address.cpp
+++ b/contracts/fio.address/fio.address.cpp
@@ -1328,12 +1328,12 @@ namespace fioio {
 
             uint64_t fee_amount = 0;
 
-            if (fioname_iter->bundleeligiblecountdown > 1) {
+            if (fioname_iter->bundleeligiblecountdown > 2) {
                 action{
                         permission_level{_self, "active"_n},
                         AddressContract,
                         "decrcounter"_n,
-                        make_tuple(fio_address, 1)
+                        make_tuple(fio_address, 2)
                 }.send();
 
             } else {
@@ -1349,8 +1349,8 @@ namespace fioio {
 
 
                 const uint64_t fee_type = fee_iter->type;
-                fio_400_assert(fee_type == 0, "fee_type", to_string(fee_type),
-                               "unexpected fee type for endpoint add_nft, expected 0", ErrorNoEndpoint);
+                fio_400_assert(fee_type == 1, "fee_type", to_string(fee_type),
+                               "unexpected fee type for endpoint add_nft, expected 1", ErrorNoEndpoint);
 
 
                 fee_amount = fee_iter->suf_amount;
@@ -1450,6 +1450,9 @@ namespace fioio {
                                                                     string(nftobj->token_id.c_str()) +
                                                                     string(nftobj->chain_code.c_str())));
 
+                fio_400_assert(nft_iter == nftbyid.end(), "fio_address", fio_address, "NFT not currently mapped",
+                            ErrorInvalidValue);
+
                 if (nft_iter != nftbyid.end()) {
                     fio_403_assert(nft_iter->fio_address == fio_address, ErrorSignature);
                     nft_iter = nftbyid.erase(nft_iter);
@@ -1484,8 +1487,8 @@ namespace fioio {
 
 
                 const uint64_t fee_type = fee_iter->type;
-                fio_400_assert(fee_type == 0, "fee_type", to_string(fee_type),
-                               "unexpected fee type for endpoint rem_nft, expected 0", ErrorNoEndpoint);
+                fio_400_assert(fee_type == 1, "fee_type", to_string(fee_type),
+                               "unexpected fee type for endpoint rem_nft, expected 1", ErrorNoEndpoint);
 
 
                 fee_amount = fee_iter->suf_amount;
@@ -1583,8 +1586,8 @@ namespace fioio {
 
 
                 const uint64_t fee_type = fee_iter->type;
-                fio_400_assert(fee_type == 0, "fee_type", to_string(fee_type),
-                               "unexpected fee type for endpoint rem_all_nfts, expected 0", ErrorNoEndpoint);
+                fio_400_assert(fee_type == 1, "fee_type", to_string(fee_type),
+                               "unexpected fee type for endpoint rem_all_nfts, expected 1", ErrorNoEndpoint);
 
 
                 fee_amount = fee_iter->suf_amount;

--- a/contracts/fio.address/fio.address.cpp
+++ b/contracts/fio.address/fio.address.cpp
@@ -1450,7 +1450,7 @@ namespace fioio {
                                                                     string(nftobj->token_id.c_str()) +
                                                                     string(nftobj->chain_code.c_str())));
 
-                fio_400_assert(nft_iter != nftbyid.end(), "fio_address", fio_address, "NFT not currently mapped",
+                fio_400_assert(nft_iter != nftbyid.end(), "fio_address", fio_address, "NFT not found",
                             ErrorInvalidValue);
 
                 if (nft_iter != nftbyid.end()) {
@@ -1461,7 +1461,7 @@ namespace fioio {
 
             } // for auto nftobj
 
-            fio_400_assert(count_erase > 0, "fio_address", fio_address, "NFT not currently mapped",
+            fio_400_assert(count_erase > 0, "fio_address", fio_address, "No NFTs",
                            ErrorInvalidFioNameFormat);
 
             uint64_t fee_amount = 0;


### PR DESCRIPTION
-addnft decrement bundle by 2
-addnft, remnft, remallnft fee type check for endpoints changed to 1
-remnft provides "NFT not currently mapped" error if one encountered in the list does not exist instead of passing over it 