### PR TITLE
FIP-21 staking -- BUGFIX  unstake, change exception to be the total sufs checked against the amount

### DIFF
--- a/contracts/fio.staking/fio.staking.cpp
+++ b/contracts/fio.staking/fio.staking.cpp
@@ -351,7 +351,7 @@ public:
         uint128_t got_suf_big = fiointdivwithrounding(interim_usrplctp, (uint128_t) gstaking.last_global_srp_count); // Then are divided by LGSRP
         totalsufsthisunstake = (uint64_t) got_suf_big;
         uint64_t totalrewardamount = totalsufsthisunstake - amount;
-        eosio_assert(srps_this_unstake >= amount, " unstake error -- srps this unstake must be >= amount.");
+        eosio_assert(totalsufsthisunstake >= amount, " unstake error -- total sufs this unstake must be >= amount.");
         uint64_t tenpercent = fiointdivwithrounding(totalrewardamount,(uint64_t) 10);
         uint64_t stakingrewardamount = totalrewardamount - tenpercent;
         uint64_t tpidrewardamount = tenpercent;


### PR DESCRIPTION
on unstake change incorrect exception logic (which was using the SRPs instead of the SUFs) to be the total sufs checked against the amount...