### PR TITLE
FIP-21 Staking -- add a new system action to set an account unlimited

### DIFF
--- a/contracts/fio.system/include/fio.system/fio.system.hpp
+++ b/contracts/fio.system/include/fio.system/fio.system.hpp
@@ -361,6 +361,9 @@ public:
                       const uint32_t &payouts);
 
     [[eosio::action]]
+    void setnolimits(const name &account);
+
+    [[eosio::action]]
     void onblock(ignore <block_header> header);
 
     // functions defined in delegate_bandwidth.cp

--- a/contracts/fio.system/src/fio.system.cpp
+++ b/contracts/fio.system/src/fio.system.cpp
@@ -198,6 +198,14 @@ namespace eosiosystem {
         check(version.value == 0, "unsupported version for init action");
     }
 
+    void eosiosystem::system_contract::setnolimits(const name &account) {
+        eosio_assert((has_auth(SYSTEMACCOUNT) || has_auth(FIOSYSTEMACCOUNT)),
+                     "missing required authority of fio.system or eosio");
+        check(is_account(account),"account must pre exist");
+        set_resource_limits(account.value, -1, -1, -1);
+    }
+
+
     //use this action to initialize the locked token holders table for the FIO protocol.
     void eosiosystem::system_contract::addlocked(const name &owner, const int64_t &amount,
             const int16_t &locktype) {
@@ -291,7 +299,7 @@ EOSIO_DISPATCH( eosiosystem::system_contract,
 // native.hpp (newaccount definition is actually in fio.system.cpp)
 (newaccount)(addaction)(remaction)(updateauth)(deleteauth)(linkauth)(unlinkauth)(canceldelay)(onerror)(setabi)
 // fio.system.cpp
-(init)(addlocked)(addgenlocked)(modgenlocked)(setparams)(setpriv)
+(init)(setnolimits)(addlocked)(addgenlocked)(modgenlocked)(setparams)(setpriv)
         (rmvproducer)(updtrevision)
 // delegate_bandwidth.cpp
         (updatepower)


### PR DESCRIPTION
add a new system action to set an account unlimited.


when a new contract is created on chain, the account that is created gets created with limited RAM. This is different than when accounts are created at chain genesis, at genesis accounts are created with unlimited RAM (because they are created by the bios node during startup). So to compensate for this limitation of account creation the FIO protocol must add an action that will set a new account to be unlimited, this permits new contracts to be added to the FIO protocol without any changes to the FIO Core code.