### PR TITLE
FIP-21 Staking --update ram bump for staking to become 512, set enable to nov22 2021 0800 MST

### DIFF
--- a/contracts/fio.common/fio.common.hpp
+++ b/contracts/fio.common/fio.common.hpp
@@ -461,8 +461,8 @@ namespace fioio {
     static const uint64_t INITIALACCOUNTRAM  = 25600;
     static const uint64_t ADDITIONALRAMBPDESCHEDULING = 25600;
 
-    static const uint64_t STAKEFIOTOKENSRAM = 256; //integrated.
-    static const uint64_t UNSTAKEFIOTOKENSRAM = 256; //integrated.
+    static const uint64_t STAKEFIOTOKENSRAM = 512; //integrated.
+    static const uint64_t UNSTAKEFIOTOKENSRAM = 512; //integrated.
     static const uint64_t REGDOMAINRAM  = 2560;  //integrated.
     static const uint64_t REGADDRESSRAM = 2560; //integrated.
     static const uint64_t ADDADDRESSRAM = 512; //integrated.

--- a/contracts/fio.staking/fio.staking.cpp
+++ b/contracts/fio.staking/fio.staking.cpp
@@ -12,7 +12,7 @@
 #include <fio.fee/fio.fee.hpp>
 #include <fio.system/include/fio.system/fio.system.hpp>
 
-#define ENABLESTAKINGREWARDSEPOCHSEC  1627686000  //July 30 5:00PM MST 11:00PM GMT
+#define ENABLESTAKINGREWARDSEPOCHSEC  1637593200//NOV 22 2021 0800 MST
 
 namespace fioio {
 


### PR DESCRIPTION
set ram bumps to become 512 for stake and unstake