### PR TITLE
FIP-21 Staking -- BD-3164 update to properly process fees when an account has only locked tokens

### DIFF
--- a/contracts/fio.staking/fio.staking.cpp
+++ b/contracts/fio.staking/fio.staking.cpp
@@ -180,7 +180,7 @@ public:
         fio_400_assert(max_fee >= 0, "amount", to_string(max_fee), "Invalid fee value",ErrorInvalidValue);
         fio_400_assert(validateTPIDFormat(tpid), "tpid", tpid,"TPID must be empty or valid FIO address",ErrorPubKeyValid);
 
-        auto stakeablebalance = eosio::token::computeusablebalance(actor,false);
+        auto stakeablebalance = eosio::token::computeusablebalance(actor,false,false);
         fio_400_assert(stakeablebalance >= (paid_fee_amount + (uint64_t)amount), "amount", to_string(stakeablebalance), "Insufficient balance.",
                        ErrorMaxFeeExceeded);
 
@@ -272,7 +272,7 @@ public:
         eosio_assert(astakeiter->account == actor,"incacctstake, actor accountstake lookup error." );
         fio_400_assert(astakeiter->total_staked_fio >= amount, "amount", to_string(amount), "Cannot unstake more than staked.",
                        ErrorInvalidValue);
-        auto stakeablebalance = eosio::token::computeusablebalance(actor,false);
+        auto stakeablebalance = eosio::token::computeusablebalance(actor,false,false);
 
         uint64_t paid_fee_amount = 0;
         //begin, bundle eligible fee logic for unstaking

--- a/contracts/fio.token/include/fio.token/fio.token.hpp
+++ b/contracts/fio.token/include/fio.token/fio.token.hpp
@@ -156,7 +156,7 @@ namespace eosio {
 
         //This action will compute the number of unlocked tokens contained within an account.
         // This considers
-        static uint64_t computeusablebalance(const name &owner,bool updatelocks){
+        static uint64_t computeusablebalance(const name &owner,bool updatelocks, bool isfee){
             uint64_t genesislockedamount = computeremaininglockedtokens(owner,updatelocks);
             uint64_t generallockedamount = computegenerallockedtokens(owner,updatelocks);
             uint64_t stakedfio = 0;
@@ -168,11 +168,16 @@ namespace eosio {
                 check(astakeiter->account == owner,"incacctstake owner lookup error." );
                 stakedfio = astakeiter->total_staked_fio;
             }
+
+            uint64_t bamount = generallockedamount + stakedfio;
+            if (!isfee){
+                bamount += genesislockedamount;
+            }
             //apply a little QC.
             const auto my_balance = eosio::token::get_balance("fio.token"_n, owner, FIOSYMBOL.code());
-            check(my_balance.amount >= (generallockedamount + genesislockedamount + stakedfio),
+            check(my_balance.amount >= bamount,
                          "computeusablebalance, amount of locked fio plus staked is greater than balance!! for " + owner.to_string() );
-            uint64_t amount = my_balance.amount - (generallockedamount + genesislockedamount + stakedfio);
+            uint64_t amount = my_balance.amount - bamount;
             return amount;
 
         }

--- a/contracts/fio.token/src/fio.token.cpp
+++ b/contracts/fio.token/src/fio.token.cpp
@@ -317,7 +317,7 @@ namespace eosio {
                        ErrorInsufficientUnlockedFunds);
 
 
-        uint64_t uamount = computeusablebalance(actor,false);
+        uint64_t uamount = computeusablebalance(actor,false,false);
         fio_400_assert(uamount >= qty.amount, "actor", to_string(actor.value),
                        "Insufficient Funds.",
                        ErrorInsufficientUnlockedFunds);
@@ -392,7 +392,7 @@ namespace eosio {
                        ErrorInsufficientUnlockedFunds);
 
 
-        int64_t amount = computeusablebalance(from,false);
+        int64_t amount = computeusablebalance(from,false,true);
         fio_400_assert(amount >= quantity.amount, "actor", to_string(from.value),
                        "Insufficient Funds.",
                        ErrorInsufficientUnlockedFunds);


### PR DESCRIPTION
fix ability to use locked tokens for fees.