### PR TITLE
 BD-3835 Operational bug fix

### DIFF
--- a/contracts/fio.system/src/voting.cpp
+++ b/contracts/fio.system/src/voting.cpp
@@ -910,11 +910,21 @@ namespace eosiosystem {
 
         update_total_votepay_share(ct, -total_inactive_vpay_share, delta_change_rate);
 
-        votersbyowner.modify(voter, same_payer, [&](auto &av) {
-            av.last_vote_weight = new_vote_weight;
-            av.producers = producers;
-            av.proxy = proxy;
-        });
+        if(voting) {
+            votersbyowner.modify(voter, same_payer, [&](auto &av) {
+                av.last_vote_weight = new_vote_weight;
+                av.producers = producers;
+                av.proxy = proxy;
+                av.is_auto_proxy = false;
+            });
+        }
+        else {
+            votersbyowner.modify(voter, same_payer, [&](auto &av) {
+                av.last_vote_weight = new_vote_weight;
+                av.producers = producers;
+                av.proxy = proxy;
+            });
+        }
     }
 
     void system_contract::updlocked(const name &owner,const uint64_t &amountremaining)


### PR DESCRIPTION
add logic to clear the is_auto_proxy when voting occurs.

SPECIAL NOTE -- these changes need tested with all voting weight tests, auto proxy tests, and complete regressions as they impact many FIO operations by impacting the update_votes logic which is used on many (if not all) actions in the FIO protocol.