### PR TITLE
Added new_funds_content and record_obt_data_content to reqobt contract ABI

### DIFF
--- a/contracts/fio.request.obt/fio.request.obt.abi
+++ b/contracts/fio.request.obt/fio.request.obt.abi
@@ -296,6 +296,52 @@
          ]
       },
       {
+         "name":"record_obt_data_content",
+         "base":"",
+         "fields":[
+            {
+               "name":"payer_public_address",
+               "type":"string"
+            },
+            {
+               "name":"payee_public_address",
+               "type":"string"
+            },
+            {
+               "name":"amount",
+               "type":"string"
+            },
+            {
+               "name":"chain_code",
+               "type":"string"
+            },
+            {
+               "name":"token_code",
+               "type":"string"
+            },
+            {
+               "name":"status",
+               "type":"string"
+            },
+            {
+               "name":"obt_id",
+               "type":"string"
+            },
+            {
+               "name":"memo",
+               "type":"string?"
+            },
+            {
+               "name":"hash",
+               "type":"string?"
+            },
+            {
+               "name":"offline_url",
+               "type":"string?"
+            }
+         ]
+      },
+      {
          "name":"newfundsreq",
          "base":"",
          "fields":[
@@ -322,6 +368,40 @@
             {
                "name":"tpid",
                "type":"string"
+            }
+         ]
+      },
+      {
+         "name":"new_funds_content",
+         "base":"",
+         "fields":[
+            {
+               "name":"payee_public_address",
+               "type":"string"
+            },
+            {
+               "name":"amount",
+               "type":"string"
+            },
+            {
+               "name":"chain_code",
+               "type":"string"
+            },
+            {
+               "name":"token_code",
+               "type":"string"
+            },
+            {
+               "name":"memo",
+               "type":"string?"
+            },
+            {
+               "name":"hash",
+               "type":"string?"
+            },
+            {
+               "name":"offline_url",
+               "type":"string?"
             }
          ]
       },


### PR DESCRIPTION
These two structs are used in the `newfundsreq` and the `recordobt` transactions, but are serialized and encrypted before being placed into the content. Because the content of these transactions is just a string, these structs don't exist in the ABI.
Adding the structs to the ABI empowers developers to use the ABI of the contract to know how to interact with the contract, instead of needing to go to some external source for documentation.