### PR TITLE
BD_3854.   handle when unstaking and not enough funds for fee.

### DIFF
--- a/contracts/fio.staking/fio.staking.cpp
+++ b/contracts/fio.staking/fio.staking.cpp
@@ -275,7 +275,7 @@ public:
         eosio_assert(astakeiter->account == actor,"incacctstake, actor accountstake lookup error." );
         fio_400_assert(astakeiter->total_staked_fio >= amount, "amount", to_string(amount), "Cannot unstake more than staked.",
                        ErrorInvalidValue);
-        auto stakeablebalance = eosio::token::computeusablebalance(actor,false,false);
+
 
         uint64_t paid_fee_amount = 0;
         //begin, bundle eligible fee logic for unstaking
@@ -314,6 +314,15 @@ public:
             }
         }
         //End, bundle eligible fee logic for staking
+
+        auto usablebalance = eosio::token::computeusablebalance(actor,false,false);
+
+        //if the usable balance is greater than the fee, we are clear of affects of
+        //fees.
+        //else if the usable balance is less than the amount of the fee, this is an error
+        // cannot unstake, insufficient funds for unstake operation.
+        fio_400_assert(usablebalance >= paid_fee_amount, "amount", to_string(usablebalance), "Insufficient funds to cover fee",
+                       ErrorMaxFeeExceeded);
 
         //RAM bump
         if (UNSTAKEFIOTOKENSRAM > 0) {

--- a/contracts/fio.token/include/fio.token/fio.token.hpp
+++ b/contracts/fio.token/include/fio.token/fio.token.hpp
@@ -180,7 +180,11 @@ namespace eosio {
             const auto my_balance = eosio::token::get_balance("fio.token"_n, owner, FIOSYMBOL.code());
             check(my_balance.amount >= bamount,
                          "computeusablebalance, amount of locked fio plus staked is greater than balance!! for " + owner.to_string() );
-            uint64_t amount = my_balance.amount - bamount;
+            uint64_t amount = 0;
+            if (my_balance.amount >= bamount){
+                amount = my_balance.amount - bamount;
+            }
+
             return amount;
 
         }


### PR DESCRIPTION
add logic to check when fee cannot be covered during unstaking. protect against unexpected math in operations.