### PR TITLE
BD-4082 Enhance locks to enforce no duplicate accounts, and handle all lock adaptation cases for unsticking

### DIFF
--- a/contracts/fio.staking/fio.staking.cpp
+++ b/contracts/fio.staking/fio.staking.cpp
@@ -439,6 +439,7 @@ public:
             uint32_t lastperiodduration = 0;
             int insertindex = -1;
             uint32_t daysforperiod = 0;
+            bool foundinsix = false;
 
             for (int i = 0; i < lockiter->periods.size(); i++) {
                 daysforperiod = (lockiter->timestamp + lockiter->periods[i].duration)/SECONDSPERDAY;
@@ -452,6 +453,7 @@ public:
                         insertintoexisting = true;
                         amountthisperiod += (stakingrewardamount + amount);
                     }
+                    foundinsix = true;
                 }
                 lastperiodduration = lockiter->periods[i].duration;
                 eosiosystem::lockperiodv2 tperiod;
@@ -495,8 +497,7 @@ public:
             }
 
             //BD-3941 begin, be sure to handle edge case where we have locks and all are in the past.
-            //BD-4082 ensure modgenlocked is called properly for all cases
-            if (newperiods.size() > 1) {
+            if (foundinsix || newperiods.size() > 1) {
                 action(
                         permission_level{get_self(), "active"_n},
                         SYSTEMACCOUNT,

--- a/contracts/fio.staking/fio.staking.cpp
+++ b/contracts/fio.staking/fio.staking.cpp
@@ -439,7 +439,6 @@ public:
             uint32_t lastperiodduration = 0;
             int insertindex = -1;
             uint32_t daysforperiod = 0;
-            bool foundinsix = false;
 
             for (int i = 0; i < lockiter->periods.size(); i++) {
                 daysforperiod = (lockiter->timestamp + lockiter->periods[i].duration)/SECONDSPERDAY;
@@ -453,7 +452,6 @@ public:
                         insertintoexisting = true;
                         amountthisperiod += (stakingrewardamount + amount);
                     }
-                    foundinsix = true;
                 }
                 lastperiodduration = lockiter->periods[i].duration;
                 eosiosystem::lockperiodv2 tperiod;
@@ -497,27 +495,30 @@ public:
             }
 
             //BD-3941 begin, be sure to handle edge case where we have locks and all are in the past.
-            if (foundinsix) {
+            //BD-4082 ensure modgenlocked is called properly for all cases
+            if (newperiods.size() > 1) {
                 action(
                         permission_level{get_self(), "active"_n},
                         SYSTEMACCOUNT,
                         "modgenlocked"_n,
                         std::make_tuple(actor, newperiods, newlockamount, newremaininglockamount, payouts)
                 ).send();
-            }else {
-                //else make the lock as if it was new, ALL perdiods in current locks are in the past!
-                bool canvote = true;
-                int64_t lockamount = (int64_t)(stakingrewardamount + amount);
+            }
+            else {
 
-                vector <eosiosystem::lockperiodv2> periods;
-                eosiosystem::lockperiodv2 period;
-                period.duration = UNSTAKELOCKDURATIONSECONDS;
-                period.amount = lockamount;
-                periods.push_back(period);
-                INLINE_ACTION_SENDER(eosiosystem::system_contract, addgenlocked)
-                        ("eosio"_n, {{_self, "active"_n}},
-                         {actor, periods, canvote, lockamount}
-                        );
+                    bool canvote = true;
+                    int64_t lockamount = (int64_t)(stakingrewardamount + amount);
+
+                    vector <eosiosystem::lockperiodv2> periods;
+                    eosiosystem::lockperiodv2 period;
+                    period.duration = UNSTAKELOCKDURATIONSECONDS;
+                    period.amount = lockamount;
+                    periods.push_back(period);
+                    INLINE_ACTION_SENDER(eosiosystem::system_contract, addgenlocked)
+                            ("eosio"_n, {{_self, "active"_n}},
+                             {actor, periods, canvote, lockamount}
+                            );
+
             }
             //BD-3941 end
         }else {

--- a/contracts/fio.system/src/fio.system.cpp
+++ b/contracts/fio.system/src/fio.system.cpp
@@ -240,6 +240,15 @@ namespace eosiosystem {
         check(is_account(owner),"account must pre exist");
         check(amount > 0,"cannot add locked token amount less or equal 0.");
 
+        //BD-4082 begin
+
+        auto locks_by_owner = _generallockedtokens.get_index<"byowner"_n>();
+        auto lockiter = locks_by_owner.find(owner.value);
+        check(lockiter == locks_by_owner.end(),"cannot emplace locks when locks pre-exist.");
+
+        //BD-4082 end
+
+
         _generallockedtokens.emplace(owner, [&](struct locked_tokens_info_v2 &a) {
             a.id = _generallockedtokens.available_primary_key();
             a.owner_account = owner;

--- a/contracts/fio.system/src/fio.system.cpp
+++ b/contracts/fio.system/src/fio.system.cpp
@@ -246,6 +246,7 @@ namespace eosiosystem {
         auto lockiter = locks_by_owner.find(owner.value);
         check(lockiter == locks_by_owner.end(),"cannot emplace locks when locks pre-exist.");
 
+
         //BD-4082 end
 
 


### PR DESCRIPTION
these changes enforce that no duplicate entries in the locktokensv2 table can be created by addgenlocks. also the unsticking logic is enhanced to provide coverage for all cases of lock adaptation when users unstake.