### PR TITLE
BD-4580 add action to transaction log for burn of domains

### DIFF
--- a/contracts/fio.address/fio.address.abi
+++ b/contracts/fio.address/fio.address.abi
@@ -504,6 +504,20 @@
         }
       ]
     },
+    {
+            "name": "modexpire",
+            "base": "",
+            "fields": [
+              {
+                "name": "fio_address",
+                "type": "string"
+              },
+              {
+                "name": "expire",
+                "type": "int64"
+              }
+            ]
+          },
       {
                "name": "burndomain",
                "base": "",
@@ -822,6 +836,11 @@
       "type": "renewaddress",
       "ricardian_contract": ""
     },
+    {
+          "name": "modexpire",
+          "type": "modexpire",
+          "ricardian_contract": ""
+        },
          {
            "name": "burndomain",
            "type": "burndomain",

--- a/contracts/fio.address/fio.address.abi
+++ b/contracts/fio.address/fio.address.abi
@@ -503,11 +503,15 @@
           "type": "string"
         }
       ]
-    },
+    }
          {
            "name": "burndomain",
            "base": "",
            "fields": [
+           {
+                           "name": "domainname",
+                           "type": "string"
+                         },
              {
                "name": "domainidx",
                "type": "uint64"

--- a/contracts/fio.address/fio.address.abi
+++ b/contracts/fio.address/fio.address.abi
@@ -504,20 +504,6 @@
         }
       ]
     },
-    {
-            "name": "modexpire",
-            "base": "",
-            "fields": [
-              {
-                "name": "fio_address",
-                "type": "string"
-              },
-              {
-                "name": "expire",
-                "type": "int64"
-              }
-            ]
-          },
       {
                "name": "burndomain",
                "base": "",
@@ -836,11 +822,6 @@
       "type": "renewaddress",
       "ricardian_contract": ""
     },
-    {
-          "name": "modexpire",
-          "type": "modexpire",
-          "ricardian_contract": ""
-        },
          {
            "name": "burndomain",
            "type": "burndomain",

--- a/contracts/fio.address/fio.address.abi
+++ b/contracts/fio.address/fio.address.abi
@@ -503,21 +503,21 @@
           "type": "string"
         }
       ]
-    }
-         {
-           "name": "burndomain",
-           "base": "",
-           "fields": [
-           {
-                           "name": "domainname",
-                           "type": "string"
-                         },
-             {
-               "name": "domainidx",
-               "type": "uint64"
-             }
-           ]
-         },
+    },
+      {
+               "name": "burndomain",
+               "base": "",
+               "fields": [
+               {
+                               "name": "domainname",
+                               "type": "string"
+                             },
+                 {
+                   "name": "domainidx",
+                   "type": "uint64"
+                 }
+               ]
+             },
     {
       "name": "burnexpired",
       "base": "",

--- a/contracts/fio.address/fio.address.abi
+++ b/contracts/fio.address/fio.address.abi
@@ -504,6 +504,16 @@
         }
       ]
     },
+         {
+           "name": "burndomain",
+           "base": "",
+           "fields": [
+             {
+               "name": "domainidx",
+               "type": "uint64"
+             }
+           ]
+         },
     {
       "name": "burnexpired",
       "base": "",
@@ -808,6 +818,11 @@
       "type": "renewaddress",
       "ricardian_contract": ""
     },
+         {
+           "name": "burndomain",
+           "type": "burndomain",
+           "ricardian_contract": ""
+         },
     {
       "name": "burnexpired",
       "type": "burnexpired",

--- a/contracts/fio.address/fio.address.cpp
+++ b/contracts/fio.address/fio.address.cpp
@@ -1409,8 +1409,6 @@ namespace fioio {
             fio_400_assert(nameiter == nameexpidx.end(), "domainidx", std::to_string(domainidx),
                     "Cannot burn domain when domain has fio handles", ErrorDomainNotFound);
 
-            print("EDEDEDEEDEDEDEDEDEDEDEDEDEDEDEDEDED burndomain erasing index ",to_string(domainidx),"\n");
-            print("EDEDEDEEDEDEDEDEDEDEDEDEDEDEDEDEDED burndomain erasing name ",domainname,"\n");
             domains.erase(domainiter);
 
 

--- a/contracts/fio.address/fio.address.cpp
+++ b/contracts/fio.address/fio.address.cpp
@@ -1389,14 +1389,15 @@ namespace fioio {
             send_response(response_string.c_str());
         }
 
-
         [[eosio::action]]
-        void burndomain(const uint64_t &domainidx) {
+        void burndomain(const string &domainname, const uint64_t &domainidx) {
             //only fio.address able to call this.
             eosio_assert(has_auth(AddressContract),
                          "missing required authority of fio.address");
 
             auto domainiter = domains.find(domainidx);
+            fio_400_assert(domainiter->name.compare(domainname) == 0, "domainname", domainname,
+                           "Domain name does not match name at index", ErrorDomainNotFound);
 
             fio_400_assert(domainiter != domains.end(), "domainidx", std::to_string(domainidx),
                            "Domain index not found", ErrorDomainNotFound);
@@ -1408,6 +1409,8 @@ namespace fioio {
             fio_400_assert(nameiter == nameexpidx.end(), "domainidx", std::to_string(domainidx),
                     "Cannot burn domain when domain has fio handles", ErrorDomainNotFound);
 
+            print("EDEDEDEEDEDEDEDEDEDEDEDEDEDEDEDEDED burndomain erasing index ",to_string(domainidx),"\n");
+            print("EDEDEDEEDEDEDEDEDEDEDEDEDEDEDEDEDED burndomain erasing name ",domainname,"\n");
             domains.erase(domainiter);
 
 
@@ -1508,7 +1511,7 @@ namespace fioio {
                                 permission_level{get_self(), "active"_n},
                                 "fio.address"_n,
                                 "burndomain"_n,
-                                std::make_tuple(index)
+                                std::make_tuple(domainiter->name,index)
                         ).send();
                         recordProcessed++;
 

--- a/contracts/fio.address/fio.address.cpp
+++ b/contracts/fio.address/fio.address.cpp
@@ -1389,6 +1389,36 @@ namespace fioio {
             send_response(response_string.c_str());
         }
 
+
+        [[eosio::action]]
+        void burndomain(const uint64_t &domainidx) {
+            //only fio.address able to call this.
+            eosio_assert(has_auth(AddressContract),
+                         "missing required authority of fio.address");
+
+            auto domainiter = domains.find(domainidx);
+
+            fio_400_assert(domainiter != domains.end(), "domainidx", std::to_string(domainidx),
+                           "Domain index not found", ErrorDomainNotFound);
+
+            const auto domainhash = domainiter->domainhash;
+            auto nameexpidx = fionames.get_index<"bydomain"_n>();
+            auto nameiter = nameexpidx.find(domainhash);
+
+            fio_400_assert(nameiter == nameexpidx.end(), "domainidx", std::to_string(domainidx),
+                    "Cannot burn domain when domain has fio handles", ErrorDomainNotFound);
+
+            domains.erase(domainiter);
+
+
+            const string response_string = string("{\"status\": \"OK\" },\"");
+
+            fio_400_assert(transaction_size() <= MAX_TRX_SIZE, "transaction_size", std::to_string(transaction_size()),
+                           "Transaction is too large", ErrorTransactionTooLarge);
+
+            send_response(response_string.c_str());
+        }
+
         /*
          * This action will look for expired domains, then look for expired addresses, it will burn a total
          * of 25 addresses each time called. please see the code for the logic of identifying expired domains
@@ -1474,7 +1504,12 @@ namespace fioio {
                     }
 
                     if (nameiter == nameexpidx.end()) {
-                        domains.erase(domainiter);
+                        action(
+                                permission_level{get_self(), "active"_n},
+                                "fio.address"_n,
+                                "burndomain"_n,
+                                std::make_tuple(index)
+                        ).send();
                         recordProcessed++;
 
                         // Find any domains listed for sale on the fio.escrow contract table
@@ -2695,6 +2730,6 @@ namespace fioio {
     };
 
     EOSIO_DISPATCH(FioNameLookup,(regaddress)(addaddress)(remaddress)(remalladdr)(regdomain)(renewdomain)(renewaddress)
-    (setdomainpub)(burnexpired)(decrcounter)(bind2eosio)(burnaddress)(xferdomain)(xferaddress)(addbundles)(xferescrow)
+    (setdomainpub)(burnexpired)(burndomain)(decrcounter)(bind2eosio)(burnaddress)(xferdomain)(xferaddress)(addbundles)(xferescrow)
     (addnft)(remnft)(remallnfts)(burnnfts)(regdomadd)(updcryptkey))
 }


### PR DESCRIPTION
this is for the wrapping of fio domains, this will permit oracles to know when a domain is burned and take appropriate actions to burn the associated wrapped domain.