### PR TITLE
BD-4624 readme and release doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# FIO
-The Foundation for Interwallet Operability (FIO) or, in short, the FIO Protocol, is an open-source project based on EOSIO 1.8+.
+# FIO.Contracts
+The Foundation for Interwallet Operability (FIO) or, in short, the FIO Protocol, is an open-source project based on EOSIO 1.8+. The smart contracts provide the basic functions of the FIO blockchain automating the execution of "agreements" by the blockchain producers for such things as account creation and use, fees, and voting.
 
 * For information on FIO Protocol, visit [FIO](https://fio.net).
 * For information on the FIO Chain, API, and SDKs, including detailed clone, build and deploy instructions, visit [FIO Protocol Developer Hub](https://dev.fio.net).
@@ -7,9 +7,7 @@ The Foundation for Interwallet Operability (FIO) or, in short, the FIO Protocol,
 * To contribute, please review [Contributing to FIO](CONTRIBUTING.md)
 * To join the community, visit [Discord](https://discord.com/invite/pHBmJCc)
 
-## Contracts
-Smart contracts that provide some of the basic functions of the FIO blockchain
-
+## Contract Summary
 This repository contains examples of these privileged contracts that are useful when deploying, managing, and/or using an FIO blockchain.  They are provided for reference purposes:
 
    * [eosio.bios](./contracts/eosio.bios)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-# fio.contracts
+# FIO
+The Foundation for Interwallet Operability (FIO) or, in short, the FIO Protocol, is an open-source project based on EOSIO 1.8+.
 
-## Version : 2.9.0
+* For information on FIO Protocol, visit [FIO](https://fio.net).
+* For information on the FIO Chain, API, and SDKs, including detailed clone, build and deploy instructions, visit [FIO Protocol Developer Hub](https://dev.fio.net).
+* To get updates on the development roadmap, visit [FIO Improvement Proposals](https://github.com/fioprotocol/fips). Anyone is welcome and encouraged to contribute.
+* To contribute, please review [Contributing to FIO](CONTRIBUTING.md)
+* To join the community, visit [Discord](https://discord.com/invite/pHBmJCc)
 
+## Contracts
 Smart contracts that provide some of the basic functions of the FIO blockchain
 
 This repository contains examples of these privileged contracts that are useful when deploying, managing, and/or using an FIO blockchain.  They are provided for reference purposes:
@@ -23,19 +29,34 @@ The following unprivileged contract(s) are also part of the system.
    * [fio.tpid](./contracts/fio.tpid)
    * [fio.treasury](./contracts/fio.treasury)
 
-Dependencies:
-* [fio.cdt v1.5.x](https://github.com/fioprotocol/fio.cdt/)
-
 ## License
-
-[MIT](./LICENSE)
+[FIO Contracts License](./LICENSE)
 
 The included icons are provided under the same terms as the software and accompanying documentation, the MIT License.  We welcome contributions from the artistically-inclined members of the community, and if you do send us alternative icons, then you are providing them under those same terms.
 
-## Information on FIO
+## Release Information
+* [TestNet Releases](docs/releases-testnet.md)
+* [MainNet Releases](docs/releases.md)
 
-For information on FIO, visit the [FIO website](https://fio.foundation).
+## Build Information
+The build script is located in main directory. Note that smart contracts are NOT installed per say; they are uploaded to the chain via clio, if a development chain, or via a multi-sig if a production chain.
 
-For information on the FIO Chain, API, and SDKs visit the [FIO Protocol Developer Hub](https://developers.fioprotocol.io).
+### Build FIO smart contract
+The build script is straight-forward; it checks for any dependencies, then builds the contracts, putting the artifacts into the build directory.
 
-To get updates on the development roadmap, releases, and technical documentation visit the [development wiki](https://fioprotocol.atlassian.net/jira/software/c/projects/BD/boards/2/roadmap).
+To build, first change to the `~/fioprotocol/fio.contracts` folder, then execute the script as follows:
+
+```shell
+./build.sh
+```
+
+The build process writes all content to the `build` folder.
+
+### Dependencies:
+[fio.cdt](https://github.com/fioprotocol/fio.cdt/tree/release/1.5.x)
+fio.cdt, version 1.5.x, must be installed onto the build machine in order for the contracts to successfully build. This can be done by cloning the fio.cdt repo, then running build.sh and install.sh. Note that the fio.cdt artifacts are installed into `/usr/local` under the folder eosio.cdt and links are created to these artifacts in `/usr/local/bin`. Note: fio.cdt is a customized version of eosio.cdt but as such any installed artifacts retain the prefix of eosio.
+
+[fio](https://github.com/fioprotocol/fio/)
+While the FIO core blockchain is not a direct dependency of fio.contracts, in order to successfully execute contract functionality, getters may be called that are part of the blockchain. FIO contracts are backward compatible* to multiple versions of the blockchain. The latest release of fio.contracts aligns to the latest release of the fio.blockchain. The latest release may be found [here](https://github.com/fioprotocol/fio/releases).
+
+* A forking change, one that includes a change to protocol, or the basic set of rules of that blockchain, mandates a minimum version of the blockchain that a version of that chain's contracts may operate successfully.

--- a/docs/releases-testnet.md
+++ b/docs/releases-testnet.md
@@ -1,0 +1,413 @@
+# Testnet Release History
+
+## v2.10.0-rc-1
+#### ABI
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | 3af458ff9d51886bcc9f78defd79a3647603b96420e5f16a2bae3297483f4513 |  |
+| eosio.wrap | d725f18bd716feea7ef33e7c12b5e1506fc526b713613f3a50d9c243195ef07c |  |
+| fio.system | 692057848a5a1ee40f4c337ae97954ac2bbba2631b539f7a8d06ed21aea3475b |  |
+| fio.address | 50fb8fc06375e525d6d516ec5a330373a023351090a0f508ba94dbbedd706a7b |  |
+| fio.escrow | e6cefdcf616dbc882217c9cedba76daa4076ee016c5080b8cf829c1414c296be |  |
+| fio.fee | 90b15dc1e8985eef6b358b06a9886c435b5f304724f31a28de58178f86061fe0 |  |
+| fio.oracle | 90a4e3e3458630b735b848b89f41ecaeb561017f531ea92d792f20d71419da71 |  |
+| fio.perms | b4c843edc77d01d1dd174aaee472523650ccb8f4032930e8e2e8c489ab9ad383 |  |
+| fio.request.obt | 09bbbdd2d6982ea24665150373ce07f371fee05786f53c5bd867263d9b6aea1c |  |
+| fio.staking | 9e2b839e35a567f5e86e3ed7aa63c8f7b025606d2a89ac558f5bf7eaab622904 |  |
+| fio.token | 776f99a74d28286512b7e00e5642c5a226412c6fffb25733c8fb18e93d6a03c4 |  |
+| fio.tpid | c10ac4f3037f80d430d5f3dbbc6bb3be7734d28a46b8a203dc72f058eb4eb644 |  |
+| fio.treasury | b183e2086f1be9918c1a44fffee16a8cccac325f619d640de21dec3cf9089827 |  |
+
+#### WASM
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | f4827d64e1f32dd7a5b879ebe8e7d6639e8593a690119ef9a65fb750ea82c2fc |  |
+| eosio.wrap | 4d9b06f62cb3f7666844883bf461535b7c04015f5fb28ad604a0bb0e952fd27d |  |
+| fio.system | 69457d9c9b70c3615d7cd84b7f71b284f9e62ed17005e404aa603addf6b42b69 |  |
+| fio.address | 321a9067738b6aefa90c8177305690ab2b3849a3422a2f23d139043694012488 |  |
+| fio.escrow | 34029f7e857cd2d0287053b8476b58613a63ccf5afe7e6e4af4b883d91ed901a |  |
+| fio.fee | ba55341a6d727619b38d0ca6b772a2b3a5254ecb3f6b1cee67bd32d28adbe9ac |  |
+| fio.oracle | 76e454a444151a204fbabb9a09b43cf9a5fb7e70f2141be3b80e22d9be974862 |  |
+| fio.perms | 01eecf5df8d2d64d8e984c176391235b360b58f630014b025307047709e7b90a |  |
+| fio.request.obt | f9b82624ae54ceaf24f26a1628b3cbbb6a0f9823eab47378e892a4948ef059f4 |  |
+| fio.staking | e97194a20c84f9aa70772d641987dcbc7fb8b5591bb912bb3360a96641096600 |  |
+| fio.token | 5c493d1eaf51735a4c05a9679a7ded33f1535694140639e4dbe4dff9b3a591f6 |  |
+| fio.tpid | 80232eb0842e3d0b8320b6efa76a5f877fc63f06a38166ad73e5d726f8590420 |  |
+| fio.treasury | 810558b1141f885127100ff99e9a8e5098cf8f56b0566de1ab9b1763dc1ac3f0 |  |
+
+## v2.9.0-rc1
+#### ABI
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | 3af458ff9d51886bcc9f78defd79a3647603b96420e5f16a2bae3297483f4513 |  |
+| eosio.wrap | d725f18bd716feea7ef33e7c12b5e1506fc526b713613f3a50d9c243195ef07c |  |
+| fio.system | 7a70ab8e6627fd52a8bd231ceade92716ca23250e166468ce016fde16e0ea62e | * |
+| fio.address | 50fb8fc06375e525d6d516ec5a330373a023351090a0f508ba94dbbedd706a7b | * |
+| fio.escrow | e6cefdcf616dbc882217c9cedba76daa4076ee016c5080b8cf829c1414c296be |  |
+| fio.fee | 90b15dc1e8985eef6b358b06a9886c435b5f304724f31a28de58178f86061fe0 |  |
+| fio.oracle | 90a4e3e3458630b735b848b89f41ecaeb561017f531ea92d792f20d71419da71 |  |
+| fio.perms | b4c843edc77d01d1dd174aaee472523650ccb8f4032930e8e2e8c489ab9ad383 | * |
+| fio.request.obt | 09bbbdd2d6982ea24665150373ce07f371fee05786f53c5bd867263d9b6aea1c |  |
+| fio.staking | 9e2b839e35a567f5e86e3ed7aa63c8f7b025606d2a89ac558f5bf7eaab622904 |  |
+| fio.token | 776f99a74d28286512b7e00e5642c5a226412c6fffb25733c8fb18e93d6a03c4 |  |
+| fio.tpid | c10ac4f3037f80d430d5f3dbbc6bb3be7734d28a46b8a203dc72f058eb4eb644 |  |
+| fio.treasury | b183e2086f1be9918c1a44fffee16a8cccac325f619d640de21dec3cf9089827 |  |
+
+#### WASM
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | f4827d64e1f32dd7a5b879ebe8e7d6639e8593a690119ef9a65fb750ea82c2fc | * |
+| eosio.wrap | 4d9b06f62cb3f7666844883bf461535b7c04015f5fb28ad604a0bb0e952fd27d |  |
+| fio.system | 4053a572330be0c4fab0c791747fe5da0a4f45fea880d27dd707b0fede06e05c | * |
+| fio.address | 72c258fbcb0b328960bdbc4fc521d76cc53e5517bb5f5f2bf991d08030ddae6b | * |
+| fio.escrow | 9292ab4d74f55eb649decace4ab5a8337c55605090e3d9a8d53342dafb270a06 | * |
+| fio.fee | 078282d69cbb956849d6c068f7a019643f45d09e54e927e97669875838a93ef8 |  |
+| fio.oracle | ca22e502f0a896006e0305ab753846ea2fe6f9bc2f17fa73bb7beadced7ab62e | * |
+| fio.perms | ecfa295ab3ba2447fc517fd3750385e15ce154917e2431097c296ba86f76015a | * |
+| fio.request.obt | aa24b58384b385843cfd4149d0e0e13818825f262fe9d15d362ab4a040b81f90 | * |
+| fio.staking | df5039e443090e94f37a4006d0c72a713780d1df07abf011cb954a28999a19c8 | * |
+| fio.token | c9c904fed2f89e9813073d3da37f511eeaa2157fc82b04cfbef9bd7404385d69 | * |
+| fio.tpid | 80232eb0842e3d0b8320b6efa76a5f877fc63f06a38166ad73e5d726f8590420 | * |
+| fio.treasury | af6cdeca53561cef71ff7b241fa9f3c99db3e15033a577ae0de62fad6a9f4395 | * |
+
+## v2.8.1-rc1
+#### ABI
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | 3af458ff9d51886bcc9f78defd79a3647603b96420e5f16a2bae3297483f4513 |  |
+| eosio.wrap | d725f18bd716feea7ef33e7c12b5e1506fc526b713613f3a50d9c243195ef07c |  |
+| fio.system | dd3e28cf8bd215b30805dd11a8dffb3c6c902e64a7bb57c233086ff9b7686265 |  |
+| fio.address | ff0940dadd16cdd36f525fb03d29b60fe1e39c0889372661a4709255376499ef |  |
+| fio.escrow | e6cefdcf616dbc882217c9cedba76daa4076ee016c5080b8cf829c1414c296be |  |
+| fio.fee | 90b15dc1e8985eef6b358b06a9886c435b5f304724f31a28de58178f86061fe0 |  |
+| fio.oracle | 90a4e3e3458630b735b848b89f41ecaeb561017f531ea92d792f20d71419da71 |  |
+| fio.request.obt | 09bbbdd2d6982ea24665150373ce07f371fee05786f53c5bd867263d9b6aea1c |  |
+| fio.staking | 9e2b839e35a567f5e86e3ed7aa63c8f7b025606d2a89ac558f5bf7eaab622904 |  |
+| fio.token | 776f99a74d28286512b7e00e5642c5a226412c6fffb25733c8fb18e93d6a03c4 |  |
+| fio.tpid | c10ac4f3037f80d430d5f3dbbc6bb3be7734d28a46b8a203dc72f058eb4eb644 |  |
+| fio.treasury | b183e2086f1be9918c1a44fffee16a8cccac325f619d640de21dec3cf9089827 |  |
+
+#### WASM
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | 2013d5305edb1abd2bfedfa275bc331cdbba40e6276b40983a10578ac741a39a |  |
+| eosio.wrap | 4d9b06f62cb3f7666844883bf461535b7c04015f5fb28ad604a0bb0e952fd27d |  |
+| fio.system | f199805e0ef69a5a9bb42f611d80368ae4d1d4f1626f7d7966e06de256a8898a | * |
+| fio.address | deb8ceaeecd45632d8bffc9bebd5c9a7b0220bbc849af2cecbf24988a42fa7b9 |  |
+| fio.escrow | 529658014321a22f47d3f8921733b4bc74e2b043d7ea18a07797d037abf762b3 |  |
+| fio.fee | 078282d69cbb956849d6c068f7a019643f45d09e54e927e97669875838a93ef8 |  |
+| fio.oracle | 68ff177b213018835c731b5c4d58ccbfb0d3c4f7b001e3eb2f216c676b66bb5f |  |
+| fio.request.obt | 0c08ce68d28c896653ea71af481af2161e581be0073d6ee9222d679d998c915a |  |
+| fio.staking | be328b4cfe045d02283c97ec5f247c15dd20cf7ac1cf0c3757fec36591d9dbb1 |  |
+| fio.token | 900cffbf8a2f47cf98135a3038fda4b9aa6abb78132e1a8aabaf70c25f1e512f |  |
+| fio.tpid | 77e5d4d9a80e4e5845fea49730a2a4a0199365f01692e47cf4e973597619c34a |  |
+| fio.treasury | 32d7df68a2fe460c159a91fc3ad49e55a82e1d9cffb23317b8534d14df7e1792 |  |
+
+## v2.8.0-rc2
+#### ABI
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | 3af458ff9d51886bcc9f78defd79a3647603b96420e5f16a2bae3297483f4513 |  |
+| eosio.wrap | d725f18bd716feea7ef33e7c12b5e1506fc526b713613f3a50d9c243195ef07c |  |
+| fio.system | dd3e28cf8bd215b30805dd11a8dffb3c6c902e64a7bb57c233086ff9b7686265 |  |
+| fio.address | ff0940dadd16cdd36f525fb03d29b60fe1e39c0889372661a4709255376499ef |  |
+| fio.escrow | e6cefdcf616dbc882217c9cedba76daa4076ee016c5080b8cf829c1414c296be |  |
+| fio.fee | 90b15dc1e8985eef6b358b06a9886c435b5f304724f31a28de58178f86061fe0 |  |
+| fio.oracle | 90a4e3e3458630b735b848b89f41ecaeb561017f531ea92d792f20d71419da71 |  |
+| fio.request.obt | 09bbbdd2d6982ea24665150373ce07f371fee05786f53c5bd867263d9b6aea1c |  |
+| fio.staking | 9e2b839e35a567f5e86e3ed7aa63c8f7b025606d2a89ac558f5bf7eaab622904 |  |
+| fio.token | 776f99a74d28286512b7e00e5642c5a226412c6fffb25733c8fb18e93d6a03c4 |  |
+| fio.tpid | c10ac4f3037f80d430d5f3dbbc6bb3be7734d28a46b8a203dc72f058eb4eb644 |  |
+| fio.treasury | b183e2086f1be9918c1a44fffee16a8cccac325f619d640de21dec3cf9089827 |  |
+
+#### WASM
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | 2013d5305edb1abd2bfedfa275bc331cdbba40e6276b40983a10578ac741a39a |  |
+| eosio.wrap | 4d9b06f62cb3f7666844883bf461535b7c04015f5fb28ad604a0bb0e952fd27d |  |
+| fio.system | 1277a0c9733b76570ab4eda31478dc499ba8eeb8fe4741a55d12e9d140b95bd8 | * |
+| fio.address | deb8ceaeecd45632d8bffc9bebd5c9a7b0220bbc849af2cecbf24988a42fa7b9 |  |
+| fio.escrow | 529658014321a22f47d3f8921733b4bc74e2b043d7ea18a07797d037abf762b3 |  |
+| fio.fee | 078282d69cbb956849d6c068f7a019643f45d09e54e927e97669875838a93ef8 |  |
+| fio.oracle | 68ff177b213018835c731b5c4d58ccbfb0d3c4f7b001e3eb2f216c676b66bb5f |  |
+| fio.request.obt | 0c08ce68d28c896653ea71af481af2161e581be0073d6ee9222d679d998c915a |  |
+| fio.staking | be328b4cfe045d02283c97ec5f247c15dd20cf7ac1cf0c3757fec36591d9dbb1 | * |
+| fio.token | 900cffbf8a2f47cf98135a3038fda4b9aa6abb78132e1a8aabaf70c25f1e512f |  |
+| fio.tpid | 77e5d4d9a80e4e5845fea49730a2a4a0199365f01692e47cf4e973597619c34a |  |
+| fio.treasury | 32d7df68a2fe460c159a91fc3ad49e55a82e1d9cffb23317b8534d14df7e1792 |  |
+
+
+## v2.8.0-rc1
+#### ABI
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| fio.system | dd3e28cf8bd215b30805dd11a8dffb3c6c902e64a7bb57c233086ff9b7686265 | * |
+| fio.address | ff0940dadd16cdd36f525fb03d29b60fe1e39c0889372661a4709255376499ef | * |
+| fio.escrow | e6cefdcf616dbc882217c9cedba76daa4076ee016c5080b8cf829c1414c296be | * |
+| fio.fee | 90b15dc1e8985eef6b358b06a9886c435b5f304724f31a28de58178f86061fe0 | |
+| fio.oracle | 90a4e3e3458630b735b848b89f41ecaeb561017f531ea92d792f20d71419da71 | * |
+| fio.request.obt | 09bbbdd2d6982ea24665150373ce07f371fee05786f53c5bd867263d9b6aea1c | * |
+| fio.staking | 9e2b839e35a567f5e86e3ed7aa63c8f7b025606d2a89ac558f5bf7eaab622904 | |
+| fio.token | 776f99a74d28286512b7e00e5642c5a226412c6fffb25733c8fb18e93d6a03c4 | |
+| fio.tpid | c10ac4f3037f80d430d5f3dbbc6bb3be7734d28a46b8a203dc72f058eb4eb644 | |
+| fio.treasury | b183e2086f1be9918c1a44fffee16a8cccac325f619d640de21dec3cf9089827 | |
+
+#### WASM
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| fio.system | 1e6fe63a9982a261ce09937875d3415257bb6c9ae84ec917f7882e0a87657d8d | * |
+| fio.address | deb8ceaeecd45632d8bffc9bebd5c9a7b0220bbc849af2cecbf24988a42fa7b9 | * |
+| fio.escrow | 529658014321a22f47d3f8921733b4bc74e2b043d7ea18a07797d037abf762b3 | * |
+| fio.fee | 90b15dc1e8985eef6b358b06a9886c435b5f304724f31a28de58178f86061fe0 | |
+| fio.oracle | 68ff177b213018835c731b5c4d58ccbfb0d3c4f7b001e3eb2f216c676b66bb5f| * |
+| fio.staking | b04c401d09097181ae59b35d8ac1b4e05af24327605e1936dfe0c7741feb39be | * |
+| fio.request.obt | 0c08ce68d28c896653ea71af481af2161e581be0073d6ee9222d679d998c915a | * |
+| fio.token | 900cffbf8a2f47cf98135a3038fda4b9aa6abb78132e1a8aabaf70c25f1e512f | * |
+| fio.tpid | 77e5d4d9a80e4e5845fea49730a2a4a0199365f01692e47cf4e973597619c34a | * |
+| fio.treasury | 32d7df68a2fe460c159a91fc3ad49e55a82e1d9cffb23317b8534d14df7e1792 | * |
+
+## v2.7.1-rc1
+Contract: fio.escrow<br>
+Hash: b7d2114978bb27207ff69a47d880d4897ab7dbc33566c3a5dd26880c4ec68d46<br>
+
+Contract: fio.tpid<br>
+Hash: 32814794f73c6779aefcfc8fd2d3f7ac67227d6a3b94fa2ac52add1f58481c67<br>
+
+## v2.7.0-rc1
+Contract: fio.address<br>
+Hash: aa1077380460fe73cb58ad9d108b09d4fb80aba7fe388ea9f1a88eae8b9ff3cf<br>
+
+Contract: fio.request.obt<br>
+Hash: c6ccb6b541d738ff7d111eb5cd59304c84b584c65695d6d591d3e5340bfa2dea<br>
+
+Contract: fio.system<br>
+Hash: b8b6a0287a3df4c758a5ac2b5203ed14841bb232e8ae658979b458bbac60ac7c<br>
+
+Contract: fio.token<br>
+Hash: 894a23edc27760fc2ce66932aad8edfde0b4593b935d22adcbdf21c0b9d2685e<br>
+
+Contract: fio.treasury<br>
+Hash: f1ef3aa0f73d5e9f7a04fee1c5830075f8f8d497b1d96dbcab204c4474f5592e<br>
+
+Contract: fio.staking<br>
+Hash: bb5e50708888a4fa0f04fb1ef2089435a478198bf7c92889d757a4cb68cb04ba<br>
+
+Contract: fio.escrow<br>
+Hash: 8281f88a99fba288c34b1e9c2c3d87be4271f583f0f8e5af27d72f84812dafa3<br>
+
+## v2.6.1
+Contract: fio.token<br>
+Hash: 4257df3c67a0710229c1b1f80008ab972443502182d00ac284da99a5f77a0fd4<br>
+
+Contract: fio.staking<br>
+Hash: 79270dbb18c34e10958d03aa72bf7decded78a1c5fe497af7aeb29b3fc211c80<br>
+
+## v2.6.0-rc3
+Contract: fio.staking<br>
+Hash: 743eac5283c74c3dc30feaf27486104aabf182cd44437fbee827035a299e52bd<br>
+
+## v2.6.0-rc1
+Contract: fio.treasury<br>
+Hash: 3b4ace746a3d9e6aa7f6f39ed29596956b111aa6dfe93db6b40bc1447c47230a<br>
+
+Contract: fio.tpid<br>
+Hash: c5daf656ce601b79ba7f9c6c45fc4b4a7d7617ad38f75e2e68b574bce88d9cee<br>
+
+Contract: fio.token<br>
+Hash: 4f7f0689c310a5d2be935c049a406dbf65868119bd73068d37849cf452a00958<br>
+
+Contract: fio.system<br>
+Hash: 76a875a61a6db617cb4c3ba239915a106cbf25589dcb408f6a974b1995ed5813<br>
+
+Contract: fio.request.obt<br>
+Hash: 10b5c26d6dec4da4cf43e5c966c65d437af3fe9fec76887fc3d4187c581e84b1<br>
+
+Contract: fio.fee<br>
+Hash: 078282d69cbb956849d6c068f7a019643f45d09e54e927e97669875838a93ef8<br>
+
+Contract: fio.address<br>
+Hash: c3548e8140e10861069a259af2a158f5ae5142adacbbedae78407e46547de4c0<br>
+
+Contract: eosio.msig<br>
+Hash: 2013d5305edb1abd2bfedfa275bc331cdbba40e6276b40983a10578ac741a39a<br>
+
+Contract: fio.staking<br>
+Hash: d2b46e7f82472b042dcee5f259039d71f3c43366f1d43fa186bda812886df315<br>
+
+## v2.5.0
+Contract: fio.address<br>
+Hash: b322993705cfac510a2f0a754cf6df94ee8744e9360905714e704b63f934bc99<br>
+
+## v2.5.0-rc2
+Contract: fio.address<br>
+Hash: 6d35e1a29903d8cb75c25868b8a4391777f09e4beac64c8db593ed029ca329eb<br>
+
+## v2.5.0-rc1
+Contract: fio.system<br>
+Hash: 06a0146a702552e9957c0f21f9cd7f71602872f0a34cf98d65ddfda5e10d2711<br>
+Contract: fio.reqobt<br>
+Hash: 49bc74038797d7d482914d8934ed73dfac7fde548fda2bfe9e071aa81878db48<br>
+Contract: fio.address<br>
+Hash: f472501f18da3dd129cde772e21f57b7bbd2db394b01f340d7e755c4df35b01a<br>
+Contract: fio.token<br>
+Hash: 0c997d252406dbef152c3ba38378462aad4e090fb81334fd4c496f8a568ce66d<br>
+Contract: fio.treasury<br>
+Hash: b8831584d5e304d26518ca551fd8b474e3fd7daabd0b9acf24a0c8659803e942<br>
+
+
+## v2.4.1-rc1
+Contract: fio.system<br>
+Hash: 48d1aa485d8ad3b21d5a048444c7100a1f5dc869a9c5ce1b77cc42d10c26bab2<br>
+
+## v2.4.0-rc1
+Contract: fio.reqobt<br>
+Hash: c61cd39ef16424c6f6e31dfbec1456ad92638f7f0b53ff68bdf4de0dc6cad641<br>
+Contract: fio.address<br>
+Hash: 06e211cc26b5611e90696558480314421b7b8ef29eb17268b7867c3f687fffbd<br>
+
+## v2.3.5-rc1
+Contract: fio.reqobt<br>
+Hash: cd54f179eb5913984af88cc589ec527396041bd63e2094ffb143c483e2f0c1da<br>
+Contract: fio.address<br>
+Hash: 183b0410eb9d6071ca741a94da36502eab4d808ac60a6432cae1329ca86c2a64<br>
+Contract: fio.system<br>
+Hash: bf2cf9c963c483263e279d1a2f3f968a65a5c6db86af99bb9e5d7a2d2840cc12<br>
+
+## v2.3.4-rc2
+Contract: fio.reqobt<br>
+Hash: c0509758a4d4361521e03bd9811ec7fe6b42c2f1b79b833e50ae7559e7a4a957<br>
+
+## v2.3.4-rc1
+Contract: fio.reqobt<br>
+Hash: 3baf7761207420b2862dff546239add9721b5686c6420c8cd25c89a017a4deb3<br>
+
+## v2.3.3-rc1
+Contract: fio.treasury<br>
+Hash: 5c50bf10f6aa07b5df11c9874c72f04a80622c1eaaf0a2b12bea4a9e010369b9<br>
+
+## v2.3.2-rc1
+Contract: fio.reqobt<br>
+Hash: acf8c14120e6930948e8977e9f7472054fb87066fd15da7ab1b4e5970d6885f5<br>
+
+## v2.3.1
+Contract: fio.reqobt<br>
+Hash: 7af80614ca9ea9b62c2e2542881af778b7bbb914e5692dd51ff40d6242ce136b<br>
+
+## v2.3.0-rc1
+Contract: fio.address<br>
+Hash: 0aacfee458bee8aa4ba6773bfcf05f9d3565a12e2ea03dfa4124aa32672d6948<br>
+Contract: fio.reqobt<br>
+Hash: cf79c8f0fe2948210556050cb53af11f01830c458225e16f5abbf9c3e5c52b69<br>
+Contract: fio.system<br>
+Hash: 811bd423b5d3ba3ac4760e15acfa298fa2b9896b319812a40019b37b3ecfb450<br>
+Contract: fio.token<br>
+Hash: f20c3d91844682c1ac035fee1509f1c91a934122e372ac6df45594bb3f3f171e<br>
+
+## v2.2.2-rc1
+Contract: fio.address<br>
+setabi for fio.address<br>
+Hash: 1021f32a8cb5b2b894107204b1601e3d55d58cb3f1eddb4de85f30992579fd53<br>
+Contract: fio.token<br>
+Hash: 85e057957fb3e4a3eef05518f586c155fac0fef8c26fc364fda614b7511b6dd1<br>
+Contract: fio.system<br>
+Hash: efc579769f663b838101c8ed5cbc493edd83bc4505f1c6677bcfdd57204b8395<br>
+
+## 2.2.1
+Contract: fio.address<br>
+Hash: 55fddc9aacdfbbdf7beccdcd090d1a7124f2db51558896a194cd69980cdf17eb<br>
+Contract: fio.token<br>
+Hash: 65a9fd79b787c9dca5b3636f75815359ad0c4289c2a70eca04fd2247c2f65aa5<br>
+
+## 2.2.0
+Contract: fio.address<br>
+Hash: cf2f99172a552222ca385cb64ed5eee867c3bbedc1e08e7e6d4f99f65f17ca36<br>
+Contract: fio.fee<br>
+Hash: 564c5023ddd4916517fad8cf0fda502a1a8cd64af32f8a4a4c45b6d6ee60cda4<br>
+Contract: fio.reqobt<br>
+Hash: 939181723ceae3c6b71a7a37dae90a931808035be49512958bb1d54aeb2a4b19<br>
+Contract: fio.system<br>
+Hash: 024343655e89c728f96d37f68570f24209ac991aa7801c94e083652c827e9aa6<br>
+Contract: fio.token<br>
+Hash: 6909cc89e46c118b7d5cc205e281b69397c77d4f9c675fb389a5fa3982e1503e<br>
+
+## 2.1.0
+<b>Contract:</b> eosio.msig<br>
+<b>Hash:</b> f9eaecc20eeea9705e5e5a81777244281a4770e8ff8b377d76d032ad3163ca81<br>
+<b>Contract:</b> fio.address<br>
+<b>Hash:</b> 7c4aba5e68dd71062c7a7c353e780b8a35f42b39cbfcae189923e89e37ce1941<br>
+<b>Contract:</b> fio.fee<br>
+<b>Hash:</b> 3f7752d601e03b1631ed25b484394aa8dc1fa7343416715d6e53b1ca49be9856<br>
+<b>Contract:</b> fio.request.obt<br>
+<b>Hash:</b> 9afb04a20da453208d68a08e842984933d7fa67277ae8c556c7bdfd266e56095<br>
+<b>Contract:</b> fio.system<br>
+<b>Hash:</b> 4023a1437292a8994a274d53ecabfa1a88f50740da8bc270ab260e252b5e6ebb<br>
+<b>Contract:</b> fio.token<br>
+<b>Hash:</b> cad03050846f4b1b3d73de76723153a15d8e2a13852d3ecf6fcc8aae9f2f08df<br>
+<b>Contract:</b> fio.tpid<br>
+<b>Hash:</b> 581155e4b3d7b7cd140f4455e5fdd7cae987c0d488aef79d947aa4014594a90d<br>
+<b>Contract:</b> fio.treasury<br>
+<b>Hash:</b> fe38917f22521a03c5408313d4d56aac6c3fc35fabb242baa95e1361b89da12e<br>
+
+## 2.0.1
+<b>Contract:</b> fio.address<br>
+<b>Hash:</b> 5fa536edf2cc63eae96691e7d7286de82162c0b80ee0d8b27edff5b7a92462a2<br>
+
+## 2.0.0
+<b>Contract:</b> eosio.msig<br>
+<b>Hash:</b> c6c181f177913588b425231d7bbb0da25bd87b971dcf7b4a206ae25a4ba66972<br>
+<b>Contract:</b> eosio.wrap<br>
+<b>Hash:</b> 4d9b06f62cb3f7666844883bf461535b7c04015f5fb28ad604a0bb0e952fd27d<br>
+<b>Contract:</b> fio.address<br>
+<b>Hash:</b> e85c4d3de8aad85142c15bcedb03ed56cea9e31419073f4f2a9d110a9d758144<br>
+<b>Contract:</b> fio.fee<br>
+<b>Hash:</b> 528fc05c437687b96c1bf18fed408c1abc01858095a3063a1a170ab2bcd6a288<br>
+<b>Contract:</b> fio.request.obt<br>
+<b>Hash:</b> 770ee79c6f4f30e3007f2abfc1f326da6a90a1dbfcf9ffbc900bbb393a9805c0<br>
+<b>Contract:</b> fio.system<br>
+<b>Hash:</b> b7b9d86f4a47ae908752779ae4e23fde1f84b3008816b420f34185ceb9442a10<br>
+<b>Contract:</b> fio.token<br>
+<b>Hash:</b> af415c08e2966fcf51c74e88c9ffac139ec7bb7074eaaa39f612c6b48ae5a334<br>
+<b>Contract:</b> fio.tpid<br>
+<b>Hash:</b> a4f9e644b864d6c7d697e4bb9db5825332eb18c185991240e7596d87a6877903<br>
+<b>Contract:</b> fio.treasury<br>
+<b>Hash:</b> 10e62b1e011d8fb98291b26ec109bbd69ecd284136e8a838e091626ce0678fee<br>
+
+## Testnet Reset
+TBD
+
+## 1.1.0
+Executed date: Jun 23, 2020<br>
+Proposal: updatesys11d, [Transaction](https://fio-test.bloks.io/transaction/39a77644185b74bf85b28f52c0e7da72b497ba80511f16973f2f6551015a2f59)<br>
+Proposal: updatesys11c, [Transaction](https://fio-test.bloks.io/transaction/c8e10b37beffe3131eaa9b1f0a3e291742ec223bd430cbfd8799e019caa82708)<br>
+Proposal: updatesys11b, [Transaction](https://fio-test.bloks.io/transaction/f3bcd48ebbeb58a42aec1b8b9c30e5d595693e19278c4a60d979a3a5b3654297)<br>
+Proposal: updatesys11a, [Transaction](https://fio-test.bloks.io/transaction/4a482b339dbe7dafa9fa482642c00aec8d6e9a3e54a2ccdaee8e9f7f16890484)<br>
+
+## 1.0.5
+Executed date: Jun 25, 2020<br>
+
+## 1.0.4
+Executed date: Jun 12, 2020<br>
+Contract: fio.address<br>
+Proposal: updatesysa41, [Transaction](https://fio-test.bloks.io/transaction/43b83f73a4709310cf08990f20cf2e9b0ced6a3963fe0477316b2a0e4b57f534)<br>
+
+Executed date: Jun 12, 2020<br>
+Contract: fio.fee<br>
+Proposal: updatesysf41, [Transaction](https://fio-test.bloks.io/transaction/06bc1bdd1c7e7b0b6c74eeafd3287257f3ba536497da9be5f937764a610d838a)<br><br>
+
+## 1.0.3
+Executed date: Jun 12, 2020<br>
+Contract: fio.address<br>
+Proposal: updatesysa31, [Transaction](https://fio-test.bloks.io/transaction/e23104972d3bc825df384d80ef13ee4ed442fd7b585941ea345db478069f1e77)<br>
+
+Executed date: Jun 12, 2020<br>
+Contract: fio.fee<br>
+Proposal: updatesysf31, [Transaction](https://fio-test.bloks.io/transaction/3c9098f93a3da37531a0521fb8c286fc9d0905b9cb9b0616c9e87680f1423deb)<br>
+
+Executed date: Jun 12, 2020<br>
+Contract: fio.system<br>
+Proposal: updatesyss31, [Transaction](https://fio-test.bloks.io/transaction/a87d5abe9cabecbf6c690864406d95856e5eeaecfc1be5b06bd3394226a09b5a)<br><br>
+
+## 1.0.2
+Executed date: Apr 14, 2020<br>
+Contract: fio.treasury<br>
+Proposal: updatesyst2, [Transaction](https://fio-test.bloks.io/transaction/e9f85fd30c0291af5adf5e5735e125126fb6477bcca945c3503451ae231d1257)<br><br>

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,653 @@
+# Mainnet Release History
+
+## v2.9.2
+#### ABI
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | 3af458ff9d51886bcc9f78defd79a3647603b96420e5f16a2bae3297483f4513 |  |
+| eosio.wrap | d725f18bd716feea7ef33e7c12b5e1506fc526b713613f3a50d9c243195ef07c |  |
+| fio.system | 7a70ab8e6627fd52a8bd231ceade92716ca23250e166468ce016fde16e0ea62e |  |
+| fio.address | 50fb8fc06375e525d6d516ec5a330373a023351090a0f508ba94dbbedd706a7b |  |
+| fio.escrow | e6cefdcf616dbc882217c9cedba76daa4076ee016c5080b8cf829c1414c296be |  |
+| fio.fee | 90b15dc1e8985eef6b358b06a9886c435b5f304724f31a28de58178f86061fe0 |  |
+| fio.oracle | 90a4e3e3458630b735b848b89f41ecaeb561017f531ea92d792f20d71419da71 |  |
+| fio.perms | b4c843edc77d01d1dd174aaee472523650ccb8f4032930e8e2e8c489ab9ad383 |  |
+| fio.request.obt | 09bbbdd2d6982ea24665150373ce07f371fee05786f53c5bd867263d9b6aea1c |  |
+| fio.staking | 9e2b839e35a567f5e86e3ed7aa63c8f7b025606d2a89ac558f5bf7eaab622904 |  |
+| fio.token | 776f99a74d28286512b7e00e5642c5a226412c6fffb25733c8fb18e93d6a03c4 |  |
+| fio.tpid | c10ac4f3037f80d430d5f3dbbc6bb3be7734d28a46b8a203dc72f058eb4eb644 |  |
+| fio.treasury | b183e2086f1be9918c1a44fffee16a8cccac325f619d640de21dec3cf9089827 |  |
+
+#### WASM
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | f4827d64e1f32dd7a5b879ebe8e7d6639e8593a690119ef9a65fb750ea82c2fc |  |
+| eosio.wrap | 4d9b06f62cb3f7666844883bf461535b7c04015f5fb28ad604a0bb0e952fd27d |  |
+| fio.system | a185a8a31c3bf50c4785861e3a873ecb5df5725762834e7688293d066e2b8459 |  |
+| fio.address | 72c258fbcb0b328960bdbc4fc521d76cc53e5517bb5f5f2bf991d08030ddae6b |  |
+| fio.escrow | 9292ab4d74f55eb649decace4ab5a8337c55605090e3d9a8d53342dafb270a06 |  |
+| fio.fee | 078282d69cbb956849d6c068f7a019643f45d09e54e927e97669875838a93ef8 |  |
+| fio.oracle | ca22e502f0a896006e0305ab753846ea2fe6f9bc2f17fa73bb7beadced7ab62e |  |
+| fio.perms | ecfa295ab3ba2447fc517fd3750385e15ce154917e2431097c296ba86f76015a |  |
+| fio.request.obt | aa24b58384b385843cfd4149d0e0e13818825f262fe9d15d362ab4a040b81f90 |  |
+| fio.staking | df5039e443090e94f37a4006d0c72a713780d1df07abf011cb954a28999a19c8 |  |
+| fio.token | c9c904fed2f89e9813073d3da37f511eeaa2157fc82b04cfbef9bd7404385d69 |  |
+| fio.tpid | 80232eb0842e3d0b8320b6efa76a5f877fc63f06a38166ad73e5d726f8590420 |  |
+| fio.treasury | af6cdeca53561cef71ff7b241fa9f3c99db3e15033a577ae0de62fad6a9f4395 |  |
+
+## v2.9.1
+#### ABI
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | 3af458ff9d51886bcc9f78defd79a3647603b96420e5f16a2bae3297483f4513 |  |
+| eosio.wrap | d725f18bd716feea7ef33e7c12b5e1506fc526b713613f3a50d9c243195ef07c |  |
+| fio.system | 7a70ab8e6627fd52a8bd231ceade92716ca23250e166468ce016fde16e0ea62e |  |
+| fio.address | 50fb8fc06375e525d6d516ec5a330373a023351090a0f508ba94dbbedd706a7b |  |
+| fio.escrow | e6cefdcf616dbc882217c9cedba76daa4076ee016c5080b8cf829c1414c296be |  |
+| fio.fee | 90b15dc1e8985eef6b358b06a9886c435b5f304724f31a28de58178f86061fe0 |  |
+| fio.oracle | 90a4e3e3458630b735b848b89f41ecaeb561017f531ea92d792f20d71419da71 |  |
+| fio.perms | b4c843edc77d01d1dd174aaee472523650ccb8f4032930e8e2e8c489ab9ad383 |  |
+| fio.request.obt | 09bbbdd2d6982ea24665150373ce07f371fee05786f53c5bd867263d9b6aea1c |  |
+| fio.staking | 9e2b839e35a567f5e86e3ed7aa63c8f7b025606d2a89ac558f5bf7eaab622904 |  |
+| fio.token | 776f99a74d28286512b7e00e5642c5a226412c6fffb25733c8fb18e93d6a03c4 |  |
+| fio.tpid | c10ac4f3037f80d430d5f3dbbc6bb3be7734d28a46b8a203dc72f058eb4eb644 |  |
+| fio.treasury | b183e2086f1be9918c1a44fffee16a8cccac325f619d640de21dec3cf9089827 |  |
+
+#### WASM
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | f4827d64e1f32dd7a5b879ebe8e7d6639e8593a690119ef9a65fb750ea82c2fc |  |
+| eosio.wrap | 4d9b06f62cb3f7666844883bf461535b7c04015f5fb28ad604a0bb0e952fd27d |  |
+| fio.system | 41147375fdf2dedf09c5741aca42626b6dc5e1af7548f97f530e222212430715 |  |
+| fio.address | 72c258fbcb0b328960bdbc4fc521d76cc53e5517bb5f5f2bf991d08030ddae6b |  |
+| fio.escrow | 9292ab4d74f55eb649decace4ab5a8337c55605090e3d9a8d53342dafb270a06 |  |
+| fio.fee | 078282d69cbb956849d6c068f7a019643f45d09e54e927e97669875838a93ef8 |  |
+| fio.oracle | ca22e502f0a896006e0305ab753846ea2fe6f9bc2f17fa73bb7beadced7ab62e |  |
+| fio.perms | ecfa295ab3ba2447fc517fd3750385e15ce154917e2431097c296ba86f76015a |  |
+| fio.request.obt | aa24b58384b385843cfd4149d0e0e13818825f262fe9d15d362ab4a040b81f90 |  |
+| fio.staking | df5039e443090e94f37a4006d0c72a713780d1df07abf011cb954a28999a19c8 |  |
+| fio.token | c9c904fed2f89e9813073d3da37f511eeaa2157fc82b04cfbef9bd7404385d69 |  |
+| fio.tpid | 80232eb0842e3d0b8320b6efa76a5f877fc63f06a38166ad73e5d726f8590420 |  |
+| fio.treasury | af6cdeca53561cef71ff7b241fa9f3c99db3e15033a577ae0de62fad6a9f4395 |  |
+
+## v2.9.0
+#### ABI
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | 3af458ff9d51886bcc9f78defd79a3647603b96420e5f16a2bae3297483f4513 |  |
+| eosio.wrap | d725f18bd716feea7ef33e7c12b5e1506fc526b713613f3a50d9c243195ef07c |  |
+| fio.system | 7a70ab8e6627fd52a8bd231ceade92716ca23250e166468ce016fde16e0ea62e |  |
+| fio.address | 50fb8fc06375e525d6d516ec5a330373a023351090a0f508ba94dbbedd706a7b |  |
+| fio.escrow | e6cefdcf616dbc882217c9cedba76daa4076ee016c5080b8cf829c1414c296be |  |
+| fio.fee | 90b15dc1e8985eef6b358b06a9886c435b5f304724f31a28de58178f86061fe0 |  |
+| fio.oracle | 90a4e3e3458630b735b848b89f41ecaeb561017f531ea92d792f20d71419da71 |  |
+| fio.perms | b4c843edc77d01d1dd174aaee472523650ccb8f4032930e8e2e8c489ab9ad383 |  |
+| fio.request.obt | 09bbbdd2d6982ea24665150373ce07f371fee05786f53c5bd867263d9b6aea1c |  |
+| fio.staking | 9e2b839e35a567f5e86e3ed7aa63c8f7b025606d2a89ac558f5bf7eaab622904 |  |
+| fio.token | 776f99a74d28286512b7e00e5642c5a226412c6fffb25733c8fb18e93d6a03c4 |  |
+| fio.tpid | c10ac4f3037f80d430d5f3dbbc6bb3be7734d28a46b8a203dc72f058eb4eb644 |  |
+| fio.treasury | b183e2086f1be9918c1a44fffee16a8cccac325f619d640de21dec3cf9089827 |  |
+
+#### WASM
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | f4827d64e1f32dd7a5b879ebe8e7d6639e8593a690119ef9a65fb750ea82c2fc |  |
+| eosio.wrap | 4d9b06f62cb3f7666844883bf461535b7c04015f5fb28ad604a0bb0e952fd27d |  |
+| fio.system | c9e56942f59c0fc4e411d888a860a193326e3ee9aeb9e68bb4549b1be526ff0c |  |
+| fio.address | 72c258fbcb0b328960bdbc4fc521d76cc53e5517bb5f5f2bf991d08030ddae6b |  |
+| fio.escrow | 9292ab4d74f55eb649decace4ab5a8337c55605090e3d9a8d53342dafb270a06 |  |
+| fio.fee | 078282d69cbb956849d6c068f7a019643f45d09e54e927e97669875838a93ef8 |  |
+| fio.oracle | ca22e502f0a896006e0305ab753846ea2fe6f9bc2f17fa73bb7beadced7ab62e |  |
+| fio.perms | ecfa295ab3ba2447fc517fd3750385e15ce154917e2431097c296ba86f76015a |  |
+| fio.request.obt | aa24b58384b385843cfd4149d0e0e13818825f262fe9d15d362ab4a040b81f90 |  |
+| fio.staking | df5039e443090e94f37a4006d0c72a713780d1df07abf011cb954a28999a19c8 |  |
+| fio.token | c9c904fed2f89e9813073d3da37f511eeaa2157fc82b04cfbef9bd7404385d69 |  |
+| fio.tpid | 80232eb0842e3d0b8320b6efa76a5f877fc63f06a38166ad73e5d726f8590420 |  |
+| fio.treasury | af6cdeca53561cef71ff7b241fa9f3c99db3e15033a577ae0de62fad6a9f4395 |  |
+
+## v2.8.1
+#### ABI
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | 3af458ff9d51886bcc9f78defd79a3647603b96420e5f16a2bae3297483f4513 |  |
+| eosio.wrap | d725f18bd716feea7ef33e7c12b5e1506fc526b713613f3a50d9c243195ef07c |  |
+| fio.system | dd3e28cf8bd215b30805dd11a8dffb3c6c902e64a7bb57c233086ff9b7686265 |  |
+| fio.address | ff0940dadd16cdd36f525fb03d29b60fe1e39c0889372661a4709255376499ef |  |
+| fio.escrow | e6cefdcf616dbc882217c9cedba76daa4076ee016c5080b8cf829c1414c296be |  |
+| fio.fee | 90b15dc1e8985eef6b358b06a9886c435b5f304724f31a28de58178f86061fe0 |  |
+| fio.oracle | 90a4e3e3458630b735b848b89f41ecaeb561017f531ea92d792f20d71419da71 |  |
+| fio.request.obt | 09bbbdd2d6982ea24665150373ce07f371fee05786f53c5bd867263d9b6aea1c |  |
+| fio.staking | 9e2b839e35a567f5e86e3ed7aa63c8f7b025606d2a89ac558f5bf7eaab622904 |  |
+| fio.token | 776f99a74d28286512b7e00e5642c5a226412c6fffb25733c8fb18e93d6a03c4 |  |
+| fio.tpid | c10ac4f3037f80d430d5f3dbbc6bb3be7734d28a46b8a203dc72f058eb4eb644 | |
+| fio.treasury | b183e2086f1be9918c1a44fffee16a8cccac325f619d640de21dec3cf9089827 | |
+
+#### WASM
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | 2013d5305edb1abd2bfedfa275bc331cdbba40e6276b40983a10578ac741a39a |  |
+| eosio.wrap | 4d9b06f62cb3f7666844883bf461535b7c04015f5fb28ad604a0bb0e952fd27d |  |
+| fio.system | f199805e0ef69a5a9bb42f611d80368ae4d1d4f1626f7d7966e06de256a8898a	 | * |
+| fio.address | deb8ceaeecd45632d8bffc9bebd5c9a7b0220bbc849af2cecbf24988a42fa7b9 |  |
+| fio.escrow | 529658014321a22f47d3f8921733b4bc74e2b043d7ea18a07797d037abf762b3 |  |
+| fio.fee | 078282d69cbb956849d6c068f7a019643f45d09e54e927e97669875838a93ef8 |  |
+| fio.oracle | 68ff177b213018835c731b5c4d58ccbfb0d3c4f7b001e3eb2f216c676b66bb5f |  |
+| fio.request.obt | 0c08ce68d28c896653ea71af481af2161e581be0073d6ee9222d679d998c915a |  |
+| fio.staking | be328b4cfe045d02283c97ec5f247c15dd20cf7ac1cf0c3757fec36591d9dbb1 |  |
+| fio.token | 900cffbf8a2f47cf98135a3038fda4b9aa6abb78132e1a8aabaf70c25f1e512f |  |
+| fio.tpid | 77e5d4d9a80e4e5845fea49730a2a4a0199365f01692e47cf4e973597619c34a |  |
+| fio.treasury | 32d7df68a2fe460c159a91fc3ad49e55a82e1d9cffb23317b8534d14df7e1792 |  |
+
+## v2.8.0
+#### ABI
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | 3af458ff9d51886bcc9f78defd79a3647603b96420e5f16a2bae3297483f4513 |  |
+| eosio.wrap | d725f18bd716feea7ef33e7c12b5e1506fc526b713613f3a50d9c243195ef07c |  |
+| fio.system | dd3e28cf8bd215b30805dd11a8dffb3c6c902e64a7bb57c233086ff9b7686265 | * |
+| fio.address | ff0940dadd16cdd36f525fb03d29b60fe1e39c0889372661a4709255376499ef | * |
+| fio.escrow | e6cefdcf616dbc882217c9cedba76daa4076ee016c5080b8cf829c1414c296be | * |
+| fio.fee | 90b15dc1e8985eef6b358b06a9886c435b5f304724f31a28de58178f86061fe0 |  |
+| fio.oracle | 90a4e3e3458630b735b848b89f41ecaeb561017f531ea92d792f20d71419da71 | * |
+| fio.request.obt | 09bbbdd2d6982ea24665150373ce07f371fee05786f53c5bd867263d9b6aea1c | * |
+| fio.staking | 9e2b839e35a567f5e86e3ed7aa63c8f7b025606d2a89ac558f5bf7eaab622904 |  |
+| fio.token | 776f99a74d28286512b7e00e5642c5a226412c6fffb25733c8fb18e93d6a03c4 |  |
+| fio.tpid | c10ac4f3037f80d430d5f3dbbc6bb3be7734d28a46b8a203dc72f058eb4eb644 | |
+| fio.treasury | b183e2086f1be9918c1a44fffee16a8cccac325f619d640de21dec3cf9089827 | |
+
+#### WASM
+| Contract | Hash | Update |
+| -------- | ---- | ------ |
+| eosio.msig | 2013d5305edb1abd2bfedfa275bc331cdbba40e6276b40983a10578ac741a39a |  |
+| eosio.wrap | 4d9b06f62cb3f7666844883bf461535b7c04015f5fb28ad604a0bb0e952fd27d |  |
+| fio.system | 1277a0c9733b76570ab4eda31478dc499ba8eeb8fe4741a55d12e9d140b95bd8 | * |
+| fio.address | deb8ceaeecd45632d8bffc9bebd5c9a7b0220bbc849af2cecbf24988a42fa7b9 | * |
+| fio.escrow | 529658014321a22f47d3f8921733b4bc74e2b043d7ea18a07797d037abf762b3 | * |
+| fio.fee | 078282d69cbb956849d6c068f7a019643f45d09e54e927e97669875838a93ef8 |  |
+| fio.oracle | 68ff177b213018835c731b5c4d58ccbfb0d3c4f7b001e3eb2f216c676b66bb5f | * |
+| fio.request.obt | 0c08ce68d28c896653ea71af481af2161e581be0073d6ee9222d679d998c915a | * |
+| fio.staking | be328b4cfe045d02283c97ec5f247c15dd20cf7ac1cf0c3757fec36591d9dbb1 | * |
+| fio.token | 900cffbf8a2f47cf98135a3038fda4b9aa6abb78132e1a8aabaf70c25f1e512f | * |
+| fio.tpid | 77e5d4d9a80e4e5845fea49730a2a4a0199365f01692e47cf4e973597619c34a | * |
+| fio.treasury | 32d7df68a2fe460c159a91fc3ad49e55a82e1d9cffb23317b8534d14df7e1792 | * |
+
+## v2.7.1
+Date: 2022-05-20<br>
+Contract: fio.escrow<br>
+Hash: b7d2114978bb27207ff69a47d880d4897ab7dbc33566c3a5dd26880c4ec68d46<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 7c4b9f59140973f20e38a0bc729b54af48e9a271
+
+Date: 2022-05-20<br>
+Contract: fio.tpid<br>
+Hash: 32814794f73c6779aefcfc8fd2d3f7ac67227d6a3b94fa2ac52add1f58481c67<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 7c4b9f59140973f20e38a0bc729b54af48e9a271
+
+## v2.7.0
+Date: 2022-04-12<br>
+Contract: fio.address<br>
+Hash: aa1077380460fe73cb58ad9d108b09d4fb80aba7fe388ea9f1a88eae8b9ff3cf<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 108b42fc4cbbe8969fe089f9665bad00b11ac4b6
+
+Date: 2022-04-12<br>
+Contract: fio.request.obt<br>
+Hash: c6ccb6b541d738ff7d111eb5cd59304c84b584c65695d6d591d3e5340bfa2dea<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 108b42fc4cbbe8969fe089f9665bad00b11ac4b6
+
+Date: 2022-04-12<br>
+Contract: fio.system<br>
+Hash: b8b6a0287a3df4c758a5ac2b5203ed14841bb232e8ae658979b458bbac60ac7c<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 108b42fc4cbbe8969fe089f9665bad00b11ac4b6
+
+Date: 2022-04-12<br>
+Contract: fio.token<br>
+Hash: 894a23edc27760fc2ce66932aad8edfde0b4593b935d22adcbdf21c0b9d2685e<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 108b42fc4cbbe8969fe089f9665bad00b11ac4b6
+
+Date: 2022-04-12<br>
+Contract: fio.treasury<br>
+Hash: f1ef3aa0f73d5e9f7a04fee1c5830075f8f8d497b1d96dbcab204c4474f5592e<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 108b42fc4cbbe8969fe089f9665bad00b11ac4b6
+
+Date: 2022-04-12<br>
+Contract: fio.staking<br>
+Hash: bb5e50708888a4fa0f04fb1ef2089435a478198bf7c92889d757a4cb68cb04ba<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 108b42fc4cbbe8969fe089f9665bad00b11ac4b6
+
+Date: 2022-04-12<br>
+Contract: fio.escrow<br>
+Hash: 8281f88a99fba288c34b1e9c2c3d87be4271f583f0f8e5af27d72f84812dafa3<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 108b42fc4cbbe8969fe089f9665bad00b11ac4b6
+
+## v2.6.1
+Date: 2022-01-10<br>
+Contract: fio.token<br>
+Hash: 4257df3c67a0710229c1b1f80008ab972443502182d00ac284da99a5f77a0fd4<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 50365706fba4274f97ec95e9b00c535b1eb4d937
+
+Date: 2021-12-29<br>
+Contract: fio.staking<br>
+Hash: 79270dbb18c34e10958d03aa72bf7decded78a1c5fe497af7aeb29b3fc211c80<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 50365706fba4274f97ec95e9b00c535b1eb4d937
+
+## v2.6.0
+Date: 2021-12-29<br>
+Contract: fio.reqobt<br>
+Hash: 10b5c26d6dec4da4cf43e5c966c65d437af3fe9fec76887fc3d4187c581e84b1<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: fa07399925e322f1016a4f54c2937cb5cd593910
+
+Date: 2021-12-29<br>
+Contract: fio.treasury<br>
+Hash: 3b4ace746a3d9e6aa7f6f39ed29596956b111aa6dfe93db6b40bc1447c47230a<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: fa07399925e322f1016a4f54c2937cb5cd593910
+
+Date: 2021-12-29<br>
+Contract: fio.staking<br>
+Hash: efff312f5c6118fc1c5306848c8e8b32c240f0f7e0d176f03dd609d9c4bfb9cb<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: fa07399925e322f1016a4f54c2937cb5cd593910
+
+Date: 2021-12-29<br>
+Contract: fio.tpid<br>
+Hash: c5daf656ce601b79ba7f9c6c45fc4b4a7d7617ad38f75e2e68b574bce88d9cee<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: fa07399925e322f1016a4f54c2937cb5cd593910
+
+Date: 2021-12-29<br>
+Contract: fio.token<br>
+Hash: 4f7f0689c310a5d2be935c049a406dbf65868119bd73068d37849cf452a00958<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: fa07399925e322f1016a4f54c2937cb5cd593910
+
+Date: 2021-12-29<br>
+Contract: fio.system<br>
+Hash: 76a875a61a6db617cb4c3ba239915a106cbf25589dcb408f6a974b1995ed5813<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: fa07399925e322f1016a4f54c2937cb5cd593910
+
+Date: 2021-12-29<br>
+Contract: fio.fee<br>
+Hash: 078282d69cbb956849d6c068f7a019643f45d09e54e927e97669875838a93ef8<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: fa07399925e322f1016a4f54c2937cb5cd593910
+
+Date: 2021-12-29<br>
+Contract: fio.address<br>
+Hash: c3548e8140e10861069a259af2a158f5ae5142adacbbedae78407e46547de4c0<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: fa07399925e322f1016a4f54c2937cb5cd593910
+
+Date: 2021-12-29<br>
+Contract: fio.msig<br>
+Hash: 2013d5305edb1abd2bfedfa275bc331cdbba40e6276b40983a10578ac741a39a<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: fa07399925e322f1016a4f54c2937cb5cd593910
+
+## v2.5.0
+Date: 2021-10-14<br>
+Contract: fio.reqobt<br>
+Hash: 49bc74038797d7d482914d8934ed73dfac7fde548fda2bfe9e071aa81878db48<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 45140b11b370d0a5a107b64c917db23c22125e3c
+
+Date: 2021-10-14<br>
+Contract: fio.system<br>
+Hash: 06a0146a702552e9957c0f21f9cd7f71602872f0a34cf98d65ddfda5e10d2711<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 45140b11b370d0a5a107b64c917db23c22125e3c
+
+Date: 2021-10-14<br>
+Contract: fio.token<br>
+Hash: 0c997d252406dbef152c3ba38378462aad4e090fb81334fd4c496f8a568ce66d<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 45140b11b370d0a5a107b64c917db23c22125e3c
+
+Date: 2021-10-14<br>
+Contract: fio.treasury<br>
+Hash: b8831584d5e304d26518ca551fd8b474e3fd7daabd0b9acf24a0c8659803e942<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 45140b11b370d0a5a107b64c917db23c22125e3c
+
+Date: 2021-10-14<br>
+Contract: fio.address<br>
+Hash: b322993705cfac510a2f0a754cf6df94ee8744e9360905714e704b63f934bc99<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 45140b11b370d0a5a107b64c917db23c22125e3c
+
+## v2.4.1
+Date: 2021-06-29<br>
+Contract: fio.system<br>
+Hash: b8831584d5e304d26518ca551fd8b474e3fd7daabd0b9acf24a0c8659803e942<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 67b686637247fa74168f99f23661b1331765f21a
+
+## v2.4.0
+Date: 2021-06-29<br>
+Contract: fio.reqobt<br>
+Hash: c61cd39ef16424c6f6e31dfbec1456ad92638f7f0b53ff68bdf4de0dc6cad641<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 2df2d1581f89adda396ac83e7758de13661a4d02
+
+
+Date: 2021-06-29<br>
+Contract: fio.address<br>
+Hash: 06e211cc26b5611e90696558480314421b7b8ef29eb17268b7867c3f687fffbd<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 2df2d1581f89adda396ac83e7758de13661a4d02
+
+
+## v2.3.5
+Date: 2021-05-30<br>
+Contract: fio.reqobt<br>
+Hash: cd54f179eb5913984af88cc589ec527396041bd63e2094ffb143c483e2f0c1da<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 0295e80fdd737babce64d28fa530e976a2ba3517
+
+Date: 2021-05-30<br>
+Contract: fio.address<br>
+Hash: 183b0410eb9d6071ca741a94da36502eab4d808ac60a6432cae1329ca86c2a64<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 0295e80fdd737babce64d28fa530e976a2ba3517
+
+Date: 2021-05-30<br>
+Contract: fio.system<br>
+Hash: bf2cf9c963c483263e279d1a2f3f968a65a5c6db86af99bb9e5d7a2d2840cc12<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 0295e80fdd737babce64d28fa530e976a2ba3517
+
+## v2.3.3
+Date: 2021-03-01<br>
+Contract: fio.treasury<br>
+Hash: 5c50bf10f6aa07b5df11c9874c72f04a80622c1eaaf0a2b12bea4a9e010369b9<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 24f18e27524a5ed1113a2e271d177c2ce593793b
+
+## v2.3.2
+Date: 2021-02-15<br>
+Contract: fio.reqobt<br>
+setabi for fio.reqobt<br>
+Hash: acf8c14120e6930948e8977e9f7472054fb87066fd15da7ab1b4e5970d6885f5<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 18d326c2011e27c04f25de41707b7e715c24fc67
+
+## v2.3.0
+Date: 2021-01-13<br>
+Contract: fio.address<br>
+setabi for fio.address<br>
+Hash: 0aacfee458bee8aa4ba6773bfcf05f9d3565a12e2ea03dfa4124aa32672d6948<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: cf75c0233fef966696298040d8302c714749d221
+
+Date: 2021-01-13<br>
+Contract: fio.reqobt<br>
+setabi for fio.reqobt<br>
+Hash: cf79c8f0fe2948210556050cb53af11f01830c458225e16f5abbf9c3e5c52b69<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: cf75c0233fef966696298040d8302c714749d221
+
+Date: 2021-01-13<br>
+Contract: fio.system<br>
+Hash: 811bd423b5d3ba3ac4760e15acfa298fa2b9896b319812a40019b37b3ecfb450<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: cf75c0233fef966696298040d8302c714749d221
+
+Date: 2021-01-13<br>
+Contract: fio.token<br>
+Hash: f20c3d91844682c1ac035fee1509f1c91a934122e372ac6df45594bb3f3f171e<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: cf75c0233fef966696298040d8302c714749d221
+
+## v2.2.2
+Date: 2020-12-22<br>
+Contract: fio.address<br>
+setabi for fio.address<br>
+Hash: 1021f32a8cb5b2b894107204b1601e3d55d58cb3f1eddb4de85f30992579fd53<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: def983d9dfb04e643bbabacde9577c070516e705
+
+Date: 2020-12-22<br>
+Contract: fio.token<br>
+Hash: 85e057957fb3e4a3eef05518f586c155fac0fef8c26fc364fda614b7511b6dd1<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: def983d9dfb04e643bbabacde9577c070516e705
+
+Date: 2020-12-22<br>
+Contract: fio.system<br>
+Hash: efc579769f663b838101c8ed5cbc493edd83bc4505f1c6677bcfdd57204b8395<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: def983d9dfb04e643bbabacde9577c070516e705
+
+## 2.2.1
+Date: 2020-12-18<br>
+Contract: fio.address<br>
+Hash: 55fddc9aacdfbbdf7beccdcd090d1a7124f2db51558896a194cd69980cdf17eb<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 1bce0991658d445c1fa8e01b25c160691c85123b
+
+Date: 2020-12-18<br>
+Contract: fio.token<br>
+Hash: 65a9fd79b787c9dca5b3636f75815359ad0c4289c2a70eca04fd2247c2f65aa5<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 1bce0991658d445c1fa8e01b25c160691c85123b
+
+## 2.2.0
+Date: 2020-10-20<br>
+Contract: fio.address<br>
+Hash: bc84ff6734bc36db2a1a3d3a865671c1de57517761ae3a10d4211f3f9263eb26<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 86d50c273467d9d90b0ed674af1615b32c5a8dd7<br>
+Proposal:<br>
+
+Date: 2020-10-20<br>
+Contract: fio.fee<br>
+Hash: 564c5023ddd4916517fad8cf0fda502a1a8cd64af32f8a4a4c45b6d6ee60cda4<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 86d50c273467d9d90b0ed674af1615b32c5a8dd7<br>
+Proposal:<br>
+
+Date: 2020-10-20<br>
+Contract: fio.reqobt<br>
+Hash: 939181723ceae3c6b71a7a37dae90a931808035be49512958bb1d54aeb2a4b19<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 86d50c273467d9d90b0ed674af1615b32c5a8dd7<br>
+Proposal:<br>
+
+Date: 2020-10-20<br>
+Contract: fio.system<br>
+Hash: 024343655e89c728f96d37f68570f24209ac991aa7801c94e083652c827e9aa6<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 86d50c273467d9d90b0ed674af1615b32c5a8dd7<br>
+Proposal:<br>
+
+Date: 2020-10-20<br>
+Contract: fio.token<br>
+Hash: 6909cc89e46c118b7d5cc205e281b69397c77d4f9c675fb389a5fa3982e1503e<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 86d50c273467d9d90b0ed674af1615b32c5a8dd7<br>
+Proposal:<br>
+
+## 2.1.0
+Date: 2020-09-07<br>
+Contract: fio.msig<br>
+Hash: f9eaecc20eeea9705e5e5a81777244281a4770e8ff8b377d76d032ad3163ca81<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 3e71133159e0a465505c49df43bae89b914ff1c9<br>
+Proposal:<br>
+
+Date: 2020-09-07<br>
+Contract: fio.address<br>
+Hash: 7c4aba5e68dd71062c7a7c353e780b8a35f42b39cbfcae189923e89e37ce1941<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 3e71133159e0a465505c49df43bae89b914ff1c9<br>
+Proposal:<br>
+
+Date: 2020-09-07<br>
+Contract: fio.fee<br>
+Hash: 3f7752d601e03b1631ed25b484394aa8dc1fa7343416715d6e53b1ca49be9856<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 3e71133159e0a465505c49df43bae89b914ff1c9<br>
+Proposal:<br>
+
+Date: 2020-09-07<br>
+Contract: fio.reqobt<br>
+Hash: 9afb04a20da453208d68a08e842984933d7fa67277ae8c556c7bdfd266e56095<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 3e71133159e0a465505c49df43bae89b914ff1c9<br>
+Proposal:<br>
+
+Date: 2020-09-07<br>
+Contract: fio.system<br>
+Hash: 4023a1437292a8994a274d53ecabfa1a88f50740da8bc270ab260e252b5e6ebb<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 3e71133159e0a465505c49df43bae89b914ff1c9<br>
+Proposal:<br>
+
+Date: 2020-09-07<br>
+Contract: fio.token<br>
+Hash: cad03050846f4b1b3d73de76723153a15d8e2a13852d3ecf6fcc8aae9f2f08df<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 3e71133159e0a465505c49df43bae89b914ff1c9<br>
+Proposal:<br>
+
+Date: 2020-09-07<br>
+Contract: fio.tpid<br>
+Hash: 581155e4b3d7b7cd140f4455e5fdd7cae987c0d488aef79d947aa4014594a90d<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 3e71133159e0a465505c49df43bae89b914ff1c9<br>
+Proposal:<br>
+
+Date: 2020-09-07<br>
+Contract: fio.treasury<br>
+Hash: fe38917f22521a03c5408313d4d56aac6c3fc35fabb242baa95e1361b89da12e<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 3e71133159e0a465505c49df43bae89b914ff1c9<br>
+Proposal:<br>
+
+## 2.0.0
+Date: 2020-08-03<br>
+Contract: fio.system<br>
+Hash: b7b9d86f4a47ae908752779ae4e23fde1f84b3008816b420f34185ceb9442a10<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 869227430eec58a23f8b1c5cc66d82d1eb24c4b0<br>
+Proposal:<br>
+
+## 1.0.5
+Date: 2020-06-25<br>
+Contract: fio.request.obt<br>
+Hash: 770ee79c6f4f30e3007f2abfc1f326da6a90a1dbfcf9ffbc900bbb393a9805c0<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: f88516ce2543b23b207e2dad6826ac9455cba9f4<br>
+Proposal: updatesysr5, [Transaction](https://fio.bloks.io/transaction/599f87417e835c9462ae3d7f4737209d7c6a1dd83ece549759374b7f130804e9), [Excecuted](https://fio.bloks.io/transaction/0e1ed60ebbc8d66877a7b6123c78d8b760b8391b41b1096c8cdc5b29c8594a71)<br>
+
+## 1.0.4
+Date: 2020-06-11<br>
+Contract: fio.address<br>
+Hash: e85c4d3de8aad85142c15bcedb03ed56cea9e31419073f4f2a9d110a9d758144<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: ab8dc736b6dc1830a9be8b36a2e3460b29d4cb0b<br>
+Proposal: updatesysa4, [Transaction](https://fio.bloks.io/transaction/18e12546e16852c21488f12253c5be873db058d0ef6d9e660cda571938ff3e16), [Excecuted](https://fio.bloks.io/transaction/f7480c26a8a9e365717990d2e3447739284832235331832b2418e9c1d4edb12b)<br>
+
+Date: 2020-06-11<br>
+Contract: fio.fee<br>
+Hash: 528fc05c437687b96c1bf18fed408c1abc01858095a3063a1a170ab2bcd6a288<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: ab8dc736b6dc1830a9be8b36a2e3460b29d4cb0b<br>
+Proposal: updatesysf4, [Transaction](https://fio.bloks.io/transaction/f2d1d42030891fae99b54c943e565e8d90a8b8fb632880bf63f281a302c1f30f), [Excecuted](https://fio.bloks.io/transaction/621354e5d67174547994ca6022e01af57a3901127b3af4c267b6a257e6b6e557)<br>
+
+## 1.0.3
+Date: 2020-06-05<br>
+Contract: fio.system<br>
+Hash: 036858a332b2dc0e9b23f0d1eb9c2b33d4231596c86abd83cc544ed54d5371b9<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 910106ec34d12d20ba6c7df34711281161474d2e<br>
+Proposal: updatesyss3, [Transaction](https://fio.bloks.io/transaction/32fc7ce8b8cecc5ed5b2620b769c7e94c2251cd8df835fcd8fe89cf9b85e9f4f), [Excecuted](https://fio.bloks.io/transaction/71ef93d9fdc891a40ca95f9c4fe4c474264ad0f95d5e5601bfc3dcc4faca8941)<br>
+
+## 1.0.2
+Date: 2020-04-08<br>
+Contract: fio.system<br>
+Hash: 89295851f17ca40c19cba706eb38b71a7cb3bc3f6d13b442a0dcb666e9c437c8<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 0aadd377c23dc3465fb2757ff66d41e13cbcd616<br>
+Proposal: updatesyss2, [Transaction](https://fio.bloks.io/transaction/17bafe4c7bb5945ab6fb92d03be2326a6cf1165b73d276347562e84d1a1f4549), [Excecuted](https://fio.bloks.io/transaction/0fdc92d47fa7922d64f74c93c3018b10177e5f44a5bba5be3f7519a6d24eae0c)<br>
+
+Date: 2020-04-13<br>
+Contract: fio.treasury<br>
+Hash: 10e62b1e011d8fb98291b26ec109bbd69ecd284136e8a838e091626ce0678fee<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: 77d8c9e2dcf3306e80fdcffc3f2e0fc718ff098f<br>
+Proposal: updatesyst2, [Transaction](https://fio.bloks.io/transaction/32f9d6fb03e9b37de9587417db80fc3110c329d268a717bdeb17b35aab9998ac), [Excecuted](https://fio.bloks.io/transaction/36cd0df26c46dc3178dba120d21750eeeece155803ec17458587355e3da4444c)<br>
+
+## v1.0.1
+Proposal: udpatesysa1, [Transaction](https://fio.bloks.io/transaction/85efb5b548b02db19a3ded727c6ee7d7c5b157e27396f6a9094c66aa61dc653b), [Excecuted](https://fio.bloks.io/transaction/d0fe22265d6b904853e0060922e390faecb5c06143bfd4733f8995d192855034)<br>
+
+Date: 2020-03-31<br>
+Contract: eosio.bios<br>
+Hash: f891bfbce1d2bedd1c5ccdc58b5cabf3310ca725f3fbe101cb4dbeb72a3063ad<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: bfeebb6dc55e15dd92120fc0a70c928b726eaa7e<br>
+ 
+Date: 2020-03-31<br>
+Contract: eosio.msig<br>
+Hash: c6c181f177913588b425231d7bbb0da25bd87b971dcf7b4a206ae25a4ba66972<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: bfeebb6dc55e15dd92120fc0a70c928b726eaa7e<br>
+
+Date: 2020-03-31<br>
+Contract: eosio.wrap<br>
+Hash: 4d9b06f62cb3f7666844883bf461535b7c04015f5fb28ad604a0bb0e952fd27d<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: bfeebb6dc55e15dd92120fc0a70c928b726eaa7e<br>
+
+Date: 2020-03-31<br>
+Contract: fio.address<br>
+Hash: fe50cbf9a5fd98150b4626e50e80e8fb5de360c597240d2a9ffb4c6a8354ee04<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: bfeebb6dc55e15dd92120fc0a70c928b726eaa7e<br>
+
+Date: 2020-03-31<br>
+Contract: fio.fee<br>
+Hash: 28850d3f012122d42dbff42e74b473c37a8176e91140ad0b72856dd4f6f5cf1f<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: bfeebb6dc55e15dd92120fc0a70c928b726eaa7e<br>
+	
+Date: 2020-03-31<br>
+Contract: fio.request.obt<br>
+Hash: c42f69ee234e5e9045c7ce585254b7789c6f352fb3598f5a2bbf1b45d223fbe5<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: bfeebb6dc55e15dd92120fc0a70c928b726eaa7e<br>
+
+Date: 2020-03-31<br>
+Contract: fio.system<br>
+Hash: 7fdf7c1d81422ef3f2b6490b8a0cccc2fd7769b762377e9ca52eceeb053fc76e<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: bfeebb6dc55e15dd92120fc0a70c928b726eaa7e<br>
+ 	
+Date: 2020-03-31<br>
+Contract: fio.token<br>
+Hash: af415c08e2966fcf51c74e88c9ffac139ec7bb7074eaaa39f612c6b48ae5a334<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: bfeebb6dc55e15dd92120fc0a70c928b726eaa7e<br>
+	
+Date: 2020-03-31<br>
+Contract: fio.tpid<br>
+Hash: a4f9e644b864d6c7d697e4bb9db5825332eb18c185991240e7596d87a6877903<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: bfeebb6dc55e15dd92120fc0a70c928b726eaa7e<br>
+
+Date: 2020-03-31<br>
+Contract: fio.treasury<br>
+Hash: 8d2a89a78300274e96cfa34c3a2554afca641a50c8a769b06881b4458477e08d<br>
+CDT: fio.cdt (1.5.x)<br>
+Git Commit: bfeebb6dc55e15dd92120fc0a70c928b726eaa7e<br>


### PR DESCRIPTION
Update of Readme to include build instructions and general info comparable to fio readme. Also moved fio.mainnet release documentation to docs dir.