### PR TITLE
BD-4669 audit vote get votable balance instead of spendable balance

### DIFF
--- a/contracts/fio.system/src/fio.system.cpp
+++ b/contracts/fio.system/src/fio.system.cpp
@@ -760,7 +760,7 @@ namespace eosiosystem {
                            operationcount += 2;
                        } else {
                            //get the current votable balance of the account
-                           uint64_t bal =  eosio::token::computeusablebalance(voter->owner,false, false);
+                           uint64_t bal = get_votable_balance(voter->owner);
 
                            //if the voter is not proxying to a proxy.
                            if (!voter->proxy) {


### PR DESCRIPTION
get votable balance instead of spendable

testing:


test this by making proxy accounts that have staked tokens, proxy participant accounts with staked tokens, proxy accounts with locked tokens, proxy participant accounts with locked tokens.

