### PR TITLE
fix(fio.system): rmvproducer lookup via byowner secondary index

### DIFF
--- a/contracts/fio.system/src/fio.system.cpp
+++ b/contracts/fio.system/src/fio.system.cpp
@@ -88,10 +88,12 @@ namespace eosiosystem {
     //todo need to write remove producer tests!!!!
     void eosiosystem::system_contract::rmvproducer(const name &producer) {
         require_auth(_self);
-        auto prod = _producers.find(producer.value);
-        check(prod->owner == producer,"producer not found");
-        check(prod != _producers.end(), "producer not found");
-        _producers.modify(prod, same_payer, [&](auto &p) {
+        // producers table's primary key is `id` (auto-increment); look up by owner via the byowner secondary index.
+        auto idx = _producers.get_index<"byowner"_n>();
+        auto prod = idx.find(producer.value);
+        check(prod != idx.end(), "producer not found");
+        check(prod->owner == producer, "producer not found");
+        idx.modify(prod, same_payer, [&](auto &p) {
             p.deactivate();
         });
 


### PR DESCRIPTION
Fixes #361

`rmvproducer` was calling `_producers.find(producer.value)`, which queries the `producers` multi_index on its primary key — the auto-incrementing `id` field (see `fio.system.hpp:212–255`). The lookup therefore always returned `end()` for any real producer, and the immediately-following `prod->owner == producer` dereference operated on an end iterator, producing a trace-less deferred `soft_fail`. No producer has been removable via `rmvproducer` since the table's primary key moved off of `owner.value`.

This change routes the lookup through the existing `byowner` secondary index and reorders the existence check to run **before** the dereference. The tautological `prod->owner == producer` check is preserved as a defensive post-condition to keep the diff minimal and the invariant readable at the call site.

The pattern mirrors what `unregprod` already does in `voting.cpp:273–281`.

### Verification

Reproduced on mainnet (proposal `aloha3joooqd/rmprod1`, target `1imvmzuutqjq`):

- Outer `eosio.msig::exec` — tx `2b8337d85bdd8496d95c31ffb971c56288761ba50890533feee36e86f285804a`, block 382198843 — **executed**, fees charged.
- Deferred `eosio::rmvproducer` — tx `8acb2be54126b9c7ada7435e5189c661fb32bfde7958a927e848c6966e887f65`, block 382198844 — **soft_fail**, 148µs, `traces: []`.
- Target `1imvmzuutqjq` still `is_active: 1` post-exec.

### Testing

Tests not added in this PR (the pre-existing `//todo need to write remove producer tests!!!!` comment is preserved). Suggested coverage for a follow-up:

- call `rmvproducer` with an existing producer name → assert `is_active` flips to `false`
- call with a non-existent name → assert `"producer not found"` assertion fires cleanly (no UB-abort)
