### PR TITLE
fix(fio.system): prevent proxy vote weight drift and unblock auditvote

### DIFF
--- a/contracts/fio.system/src/voting.cpp
+++ b/contracts/fio.system/src/voting.cpp
@@ -228,9 +228,6 @@ namespace eosiosystem {
             ).send();
         }
 
-
-        _audit_global_info.audit_reset = true;
-
         fio_400_assert(transaction_size() <= MAX_TRX_SIZE, "transaction_size", std::to_string(transaction_size()),
           "Transaction is too large", ErrorTransactionTooLarge);
 
@@ -305,8 +302,6 @@ namespace eosiosystem {
         processrewardsnotpid(reg_amount, get_self());
 
         //end new fees, logic for Mandatory fees.
-
-        _audit_global_info.audit_reset = true;
 
         const string response_string = string("{\"status\": \"OK\",\"fee_collected\":") +
                                  to_string(reg_amount) + string("}");
@@ -561,8 +556,6 @@ namespace eosiosystem {
             ).send();
         }
 
-        _audit_global_info.audit_reset = true;
-
         fio_400_assert(transaction_size() <= MAX_TRX_SIZE, "transaction_size", std::to_string(transaction_size()),
           "Transaction is too large", ErrorTransactionTooLarge);
 
@@ -700,8 +693,6 @@ namespace eosiosystem {
                     std::make_tuple(actor, VOTEPROXYRAM)
             ).send();
         }
-
-        _audit_global_info.audit_reset = true;
 
         fio_400_assert(transaction_size() <= MAX_TRX_SIZE, "transaction_size", std::to_string(transaction_size()),
           "Transaction is too large", ErrorTransactionTooLarge);
@@ -909,9 +900,7 @@ namespace eosiosystem {
                 votersbyowner.modify(new_proxy, same_payer, [&](auto &vp) {
                     vp.proxied_vote_weight += new_vote_weight;
                 });
-                if(new_proxy->producers.size() > 0) {
-                    propagate_weight_change(*new_proxy);
-                }
+                propagate_weight_change(*new_proxy);
             }
         } else {
             if (new_vote_weight >= 0) {
@@ -1104,8 +1093,6 @@ namespace eosiosystem {
         processrewardsnotpid(reg_amount, get_self());
         //end new fees, logic for Mandatory fees.
 
-        _audit_global_info.audit_reset = true;
-
         const string response_string = string("{\"status\": \"OK\",\"fee_collected\":") +
                                  to_string(reg_amount) + string("}");
         fio_400_assert(transaction_size() <= MAX_TRX_SIZE, "transaction_size", std::to_string(transaction_size()),
@@ -1183,8 +1170,6 @@ namespace eosiosystem {
                  {actor, false}
                 );
 
-        _audit_global_info.audit_reset = true;
-
         const string response_string = string("{\"status\": \"OK\",\"fee_collected\":") +
                                  to_string(reg_amount) + string("}");
         if (REGPROXYRAM > 0) {
@@ -1241,6 +1226,7 @@ namespace eosiosystem {
                     p.is_proxy = isproxy;
                     p.is_auto_proxy = false;
                     p.proxy = nm;
+                    p.proxied_vote_weight = 0;
                 });
             propagate_weight_change(*pitr);
             //check proxy, propagate proxy weight change.


### PR DESCRIPTION
## Summary

Three targeted fixes for a critical voting subsystem bug where `proxied_vote_weight` drifted to deeply negative values on two mainnet proxies, corrupting the block producer schedule.

**On-chain impact (FIO mainnet, 2026-04-18):**
- `tun3zfc1kk5z` (`proxy@eosphere`): `proxied_vote_weight` = **-82.59Q SUF** (should be +1.89Q)
- `hkzfdcxe11us` (`crypto@tribe`): `proxied_vote_weight` = **-30.87T SUF** (should be +16.6T)
- `total_voted_fio` had underflowed to **-9.04×10¹⁸**
- **7 of 21 block producer schedule slots were incorrect**

The corrupted state was corrected via a successful `auditvote` run (119 sequential calls during a quiet window), but the underlying code defects that caused the drift remain. This PR fixes them.

## Changes

### 1. Restore `proxied_vote_weight = 0` on proxy re-registration

**File:** `voting.cpp`, `regiproxy()` (~L1229)

Re-applies commit `085b411` which was accidentally reverted in `4a719bc` ("Cleanup PR"). Ed's original commit message:

> "new bug found, make account, proxy votes to second account, then reg account as proxy, then vote, verify total voted fio after all operations. we need to clear the proxied vote weight whenever an account registers or re-registers as a proxy."

Without this, stale `proxied_vote_weight` (including deeply negative values) survives across unreg→rereg cycles and gets reactivated in `propagate_weight_change`'s `new_weight = balance + proxied_vote_weight` calculation.

### 2. Make `propagate_weight_change` unconditional on new proxy

**File:** `voting.cpp`, `update_votes()` (~L903)

Removed the `if(new_proxy->producers.size() > 0)` condition around the `propagate_weight_change(*new_proxy)` call. The old-proxy subtract path (L893) was already unconditional. This asymmetry caused `new_proxy.last_vote_weight` to go stale when a delegator joined a proxy that hadn't voted for producers yet, producing incorrect deltas on subsequent operations.

### 3. Remove automatic `audit_reset` from vote/proxy actions

**File:** `voting.cpp`, 6 call sites removed (was at `regproducer`, `unregprod`, `voteproducer`, `voteproxy`, `unregproxy`, `regproxy`)

Every vote-related action set `audit_reset = true`, forcing any in-progress `auditvote` reconciliation to restart from phase 1. Since `auditvote` needs ~120 sequential calls to scan all 5,458 voters, a single vote action during the run invalidated all progress. On a live mainnet with any voting activity, this made `auditvote` practically unusable.

The explicit `resetaudit` action (requiring `fio.token` authority) remains available for manual resets when needed. `auditvote` is a periodic reconciliation tool — producing a snapshot of vote state is acceptable even if individual voter weights change slightly during the scan. The alternative (never completing) left the chain with -82.6Q of corrupted vote weight for an extended period.

## Root cause trace

| Commit | Effect |
|--------|--------|
| `085b411` (2023-08-14, Ed Rotthoff) | **Added** `p.proxied_vote_weight = 0;` in `regiproxy` — correct fix |
| `4a719bc` ("Cleanup PR") | **Reverted** `085b411` + removed commented clamp guards |
| `0301770` (2024-01-22, "remove unwanted code and comments") | **Removed** remaining commented guards from `update_votes` |

The `auditvote` mechanism (introduced in v2.10) was designed to address this class of drift, but the `audit_reset` race prevented it from ever completing on a live chain.

## Verification

On-chain verification was performed on 2026-04-18:
1. Full voter table scan (5,457 records) confirmed exactly 2 accounts with negative `proxied_vote_weight`
2. Delegator weight sums were computed and compared against stored values
3. `auditvote` was successfully run to completion (119 calls, all 4 phases) correcting the corrupted state
4. Producer schedule rotated to reflect corrected vote totals
